### PR TITLE
Debug tracing

### DIFF
--- a/src/libcommon/filesystem.cpp
+++ b/src/libcommon/filesystem.cpp
@@ -1,0 +1,111 @@
+#include "stdafx.h"
+#include "filesystem.h"
+#include "string.h"
+#include <stdexcept>
+
+namespace common::fs
+{
+
+void Mkdir(const std::wstring &path)
+{
+    if (path.empty())
+    {
+        return;
+    }
+
+    auto dirs = common::string::Tokenize(path, L"/\\");
+
+    //
+    // Implicit path so there is no work to be performed.
+    //
+    if (0 == dirs.size())
+    {
+        return;
+    }
+
+    //
+    // Only the volume is specified so ignore this request.
+    // TODO: It would be more correct to verify whether the volume exists.
+    //
+    if (1 == dirs.size())
+    {
+        return;
+    }
+
+    std::wstring target = L"\\\\?\\";
+
+    auto it = dirs.begin();
+
+    target.append(*it++).push_back(L'\\');
+
+    DWORD lastError = ERROR_SUCCESS;
+
+    do
+    {
+        target.append(*it++).push_back(L'\\');
+
+        //
+        // The first few levels can fail with ERROR_ACCESS_DENIED or
+        // ERROR_ALREADY_EXISTS but we keep going and check the status on the final node.
+        //
+        lastError = (CreateDirectoryW(target.c_str(), nullptr) ? ERROR_SUCCESS : GetLastError());
+    }
+    while (it != dirs.end());
+
+    if (ERROR_SUCCESS != lastError && ERROR_ALREADY_EXISTS != lastError)
+    {
+        auto msg = std::string("Failed to create directory: ").append(common::string::ToAnsi(target));
+
+        throw std::runtime_error(msg.c_str());
+    }
+}
+
+std::wstring GetPath(const std::wstring &filepath)
+{
+    if (filepath.empty())
+    {
+        return L"";
+    }
+
+    //
+    // Perhaps there's no filename included.
+    //
+    if (L'/' == *filepath.rbegin() || L'\\' == *filepath.rbegin())
+    {
+        return filepath;
+    }
+
+    auto lastSlash = filepath.find_last_of(L"/\\");
+
+    //
+    // Perhaps there's no path included.
+    //
+    if (std::wstring::npos == lastSlash)
+    {
+        return L"";
+    }
+
+    return filepath.substr(0, lastSlash + 1);
+}
+
+std::wstring GetFilename(const std::wstring &filepath)
+{
+    if (filepath.empty())
+    {
+        return L"";
+    }
+
+    auto lastSlash = filepath.find_last_of(L"/\\");
+
+    //
+    // Perhaps there's no path included.
+    //
+    if (std::wstring::npos == lastSlash)
+    {
+        return filepath;
+    }
+
+    return filepath.substr(lastSlash + 1);
+}
+
+}

--- a/src/libcommon/filesystem.h
+++ b/src/libcommon/filesystem.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <string>
+
+namespace common::fs
+{
+
+void Mkdir(const std::wstring &path);
+
+std::wstring GetPath(const std::wstring &filepath);
+
+std::wstring GetFilename(const std::wstring &filepath);
+
+}

--- a/src/libcommon/libcommon.vcxproj
+++ b/src/libcommon/libcommon.vcxproj
@@ -23,6 +23,7 @@
     <ClCompile Include="binarycomposer.cpp" />
     <ClCompile Include="com.cpp" />
     <ClCompile Include="error.cpp" />
+    <ClCompile Include="filesystem.cpp" />
     <ClCompile Include="guid.cpp" />
     <ClCompile Include="network.cpp" />
     <ClCompile Include="serialization\deserializer.cpp" />
@@ -47,6 +48,7 @@
     <ClInclude Include="buffer.h" />
     <ClInclude Include="com.h" />
     <ClInclude Include="error.h" />
+    <ClInclude Include="filesystem.h" />
     <ClInclude Include="guid.h" />
     <ClInclude Include="math.h" />
     <ClInclude Include="memory.h" />

--- a/src/libcommon/libcommon.vcxproj
+++ b/src/libcommon/libcommon.vcxproj
@@ -35,6 +35,9 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="string.cpp" />
+    <ClCompile Include="trace\consoletracesink.cpp" />
+    <ClCompile Include="trace\filetracesink.cpp" />
+    <ClCompile Include="trace\trace.cpp" />
     <ClCompile Include="wmi\connection.cpp" />
     <ClCompile Include="wmi\eventdispatcher.cpp" />
     <ClCompile Include="wmi\methodcall.cpp" />
@@ -50,6 +53,7 @@
     <ClInclude Include="error.h" />
     <ClInclude Include="filesystem.h" />
     <ClInclude Include="guid.h" />
+    <ClInclude Include="macroargument.h" />
     <ClInclude Include="math.h" />
     <ClInclude Include="memory.h" />
     <ClInclude Include="network.h" />
@@ -59,6 +63,11 @@
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="string.h" />
     <ClInclude Include="targetver.h" />
+    <ClInclude Include="trace\consoletracesink.h" />
+    <ClInclude Include="trace\filetracesink.h" />
+    <ClInclude Include="trace\itracesink.h" />
+    <ClInclude Include="trace\trace.h" />
+    <ClInclude Include="trace\xtrace.h" />
     <ClInclude Include="wmi\connection.h" />
     <ClInclude Include="wmi\eventdispatcher.h" />
     <ClInclude Include="wmi\iconnection.h" />

--- a/src/libcommon/libcommon.vcxproj.filters
+++ b/src/libcommon/libcommon.vcxproj.filters
@@ -34,6 +34,15 @@
       <Filter>wmi</Filter>
     </ClCompile>
     <ClCompile Include="filesystem.cpp" />
+    <ClCompile Include="trace\consoletracesink.cpp">
+      <Filter>trace</Filter>
+    </ClCompile>
+    <ClCompile Include="trace\filetracesink.cpp">
+      <Filter>trace</Filter>
+    </ClCompile>
+    <ClCompile Include="trace\trace.cpp">
+      <Filter>trace</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="applicationrunner.h" />
@@ -82,6 +91,22 @@
       <Filter>wmi</Filter>
     </ClInclude>
     <ClInclude Include="filesystem.h" />
+    <ClInclude Include="macroargument.h" />
+    <ClInclude Include="trace\consoletracesink.h">
+      <Filter>trace</Filter>
+    </ClInclude>
+    <ClInclude Include="trace\filetracesink.h">
+      <Filter>trace</Filter>
+    </ClInclude>
+    <ClInclude Include="trace\itracesink.h">
+      <Filter>trace</Filter>
+    </ClInclude>
+    <ClInclude Include="trace\trace.h">
+      <Filter>trace</Filter>
+    </ClInclude>
+    <ClInclude Include="trace\xtrace.h">
+      <Filter>trace</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="wmi">
@@ -89,6 +114,9 @@
     </Filter>
     <Filter Include="serialization">
       <UniqueIdentifier>{60530505-2146-473a-92fc-9c1883cfaa88}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="trace">
+      <UniqueIdentifier>{0c82bd88-7f1d-4a6c-b5e7-440e9b5dc96a}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/src/libcommon/libcommon.vcxproj.filters
+++ b/src/libcommon/libcommon.vcxproj.filters
@@ -33,6 +33,7 @@
     <ClCompile Include="wmi\wmi.cpp">
       <Filter>wmi</Filter>
     </ClCompile>
+    <ClCompile Include="filesystem.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="applicationrunner.h" />
@@ -80,6 +81,7 @@
     <ClInclude Include="wmi\wmi.h">
       <Filter>wmi</Filter>
     </ClInclude>
+    <ClInclude Include="filesystem.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="wmi">

--- a/src/libcommon/macroargument.h
+++ b/src/libcommon/macroargument.h
@@ -1,0 +1,23 @@
+#pragma once
+
+//http://www.neff.co.at/2017/04/04/Overloading-Macros-on-the-Number-of-Arguments.html
+
+// Some auxiliary macros
+#define EMPTY()
+#define EXPAND(X) X
+#define CONCAT(X,Y) X##Y
+
+// Get number of arguments passed by __VA_ARGS__
+// http://stackoverflow.com/questions/2124339/c-preprocessor-va-args-number-of-arguments
+// NUMARGS: all arguments must be castable to int
+// NARGS: pure preprocessor macro, maximum 9 arguments
+#define NUMARGS(...)  (sizeof((int[]){__VA_ARGS__})/sizeof(int))
+#define NARGS(...)  _NARGS_I(_AUGMENT(__VA_ARGS__))
+#define _AUGMENT(...) _UNUSED_, __VA_ARGS__
+#define _NARGS_I(...) EXPAND(_ARG_N(__VA_ARGS__, 8, 7, 6, 5, 4, 3, 2, 1, 0))
+#define _ARG_N(_1, _2, _3, _4, _5, _6, _7, _8, _9, count, ...) count
+
+// Overloading Macro on Number of Arguments
+// http://stackoverflow.com/questions/11761703/overloading-macro-on-number-of-arguments
+#define _VFUNC(NAME, N) CONCAT(NAME, N)
+#define VFUNC(FUNC, ...) CONCAT(_VFUNC(FUNC, NARGS(__VA_ARGS__))(__VA_ARGS__),EMPTY())

--- a/src/libcommon/trace/consoletracesink.cpp
+++ b/src/libcommon/trace/consoletracesink.cpp
@@ -1,0 +1,16 @@
+#include "stdafx.h"
+#include "consoletracesink.h"
+#include <iostream>
+
+namespace common::trace
+{
+
+void ConsoleTraceSink::trace(const wchar_t *sender, const wchar_t *message)
+{
+    //
+    // There won't be much gain in locking since we don't control wcout anyway.
+    //
+	std::wcout << sender << L": " << message << std::endl;
+}
+
+}

--- a/src/libcommon/trace/consoletracesink.cpp
+++ b/src/libcommon/trace/consoletracesink.cpp
@@ -10,7 +10,7 @@ void ConsoleTraceSink::trace(const wchar_t *sender, const wchar_t *message)
     //
     // There won't be much gain in locking since we don't control wcout anyway.
     //
-	std::wcout << sender << L": " << message << std::endl;
+    std::wcout << sender << L": " << message << std::endl;
 }
 
 }

--- a/src/libcommon/trace/consoletracesink.h
+++ b/src/libcommon/trace/consoletracesink.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "itracesink.h"
+
+namespace common::trace
+{
+
+struct ConsoleTraceSink : public ITraceSink
+{
+	void trace(const wchar_t *sender, const wchar_t *message) override;
+};
+
+}

--- a/src/libcommon/trace/consoletracesink.h
+++ b/src/libcommon/trace/consoletracesink.h
@@ -7,7 +7,7 @@ namespace common::trace
 
 struct ConsoleTraceSink : public ITraceSink
 {
-	void trace(const wchar_t *sender, const wchar_t *message) override;
+    void trace(const wchar_t *sender, const wchar_t *message) override;
 };
 
 }

--- a/src/libcommon/trace/filetracesink.cpp
+++ b/src/libcommon/trace/filetracesink.cpp
@@ -1,0 +1,42 @@
+#include "stdafx.h"
+#include "filetracesink.h"
+#include "libcommon/filesystem.h"
+#include "libcommon/string.h"
+#include <stdexcept>
+
+namespace common::trace
+{
+
+FileTraceSink::FileTraceSink(const std::wstring &file)
+{
+    common::fs::Mkdir(common::fs::GetPath(file));
+
+    m_file = CreateFileW(file.c_str(), GENERIC_WRITE, FILE_SHARE_READ, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+
+    if (INVALID_HANDLE_VALUE == m_file)
+    {
+        auto msg = std::string("Failed to create trace file: ").append(common::string::ToAnsi(file));
+
+        throw std::runtime_error(msg.c_str());
+    }
+}
+
+FileTraceSink::~FileTraceSink()
+{
+    CloseHandle(m_file);
+}
+
+void FileTraceSink::trace(const wchar_t *sender, const wchar_t *message)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    auto msg = std::wstring(sender).append(L": ").append(message).append(L"\xd\xa");
+    auto encoded = common::string::ToAnsi(msg);
+
+    if (FALSE == WriteFile(m_file, encoded.c_str(), static_cast<DWORD>(encoded.size()), nullptr, nullptr))
+    {
+        throw std::runtime_error("Failed to write trace event to disk");
+    }
+}
+
+}

--- a/src/libcommon/trace/filetracesink.h
+++ b/src/libcommon/trace/filetracesink.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "itracesink.h"
+#include <string>
+#include <mutex>
+#include <windows.h>
+
+namespace common::trace
+{
+
+class FileTraceSink : public ITraceSink
+{
+public:
+
+    FileTraceSink(const std::wstring &file);
+    ~FileTraceSink();
+
+    void trace(const wchar_t *sender, const wchar_t *message) override;
+
+private:
+
+    HANDLE m_file;
+    std::mutex m_mutex;
+};
+
+}

--- a/src/libcommon/trace/itracesink.h
+++ b/src/libcommon/trace/itracesink.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace common::trace
+{
+
+struct ITraceSink
+{
+	virtual ~ITraceSink() = 0
+	{
+	}
+
+	virtual void trace(const wchar_t *sender, const wchar_t *message) = 0;
+};
+
+}

--- a/src/libcommon/trace/itracesink.h
+++ b/src/libcommon/trace/itracesink.h
@@ -5,11 +5,11 @@ namespace common::trace
 
 struct ITraceSink
 {
-	virtual ~ITraceSink() = 0
-	{
-	}
+    virtual ~ITraceSink() = 0
+    {
+    }
 
-	virtual void trace(const wchar_t *sender, const wchar_t *message) = 0;
+    virtual void trace(const wchar_t *sender, const wchar_t *message) = 0;
 };
 
 }

--- a/src/libcommon/trace/trace.cpp
+++ b/src/libcommon/trace/trace.cpp
@@ -1,0 +1,115 @@
+#include "stdafx.h"
+#include "trace.h"
+#include <sstream>
+#include <wchar.h>
+#include <windows.h>
+
+namespace common::trace
+{
+
+typedef struct tag_SinkBucket
+{
+    uint32_t tag;
+    ITraceSink *sink;
+}
+SinkBucket;
+
+//static
+void Trace::DoTrace(const wchar_t *sender, const wchar_t *message)
+{
+#if TRACING_ENABLED == 1
+
+    auto activeSink = Sink();
+
+    if (nullptr == activeSink)
+    {
+        return;
+    }
+
+    activeSink->trace(sender, message);
+
+#else
+
+    UNREFERENCED_PARAMETER(sender);
+    UNREFERENCED_PARAMETER(message);
+
+#endif
+}
+
+//static
+void Trace::RegisterSink(ITraceSink *sink)
+{
+#if TRACING_ENABLED == 1
+
+    auto bucket = new SinkBucket { TAG_VALUE, sink };
+
+    SetEnvironmentVariableW
+    (
+        SinkKey().c_str(),
+        std::to_wstring((unsigned long long)bucket).c_str()
+    );
+
+#else
+
+    UNREFERENCED_PARAMETER(sink);
+
+#endif
+}
+
+//static
+bool Trace::HasSink()
+{
+#if TRACING_ENABLED == 1
+
+    return nullptr != Sink();
+
+#else
+
+    return false;
+
+#endif
+}
+
+//static
+ITraceSink *Trace::Sink()
+{
+    //
+    // Always read the instance from global storage.
+    // This way, it becomes possible to redirect trace messages at any time.
+    //
+
+    wchar_t bucketLocation[128];
+
+    if (0 == GetEnvironmentVariableW(SinkKey().c_str(), bucketLocation, _countof(bucketLocation)))
+    {
+        return nullptr;
+    }
+
+    auto bucket = (SinkBucket *)wcstoull(bucketLocation, nullptr, 10);
+
+    try
+    {
+        if (bucket->tag != TAG_VALUE)
+        {
+            return nullptr;
+        }
+    }
+    catch (...)
+    {
+        return nullptr;
+    }
+
+    return bucket->sink;
+}
+
+//static
+std::wstring Trace::SinkKey()
+{
+    std::wstringstream ss;
+
+    ss << L"LIBCOMMON_TRACE_SINK_" << GetCurrentProcessId();
+
+    return ss.str();
+}
+
+}

--- a/src/libcommon/trace/trace.h
+++ b/src/libcommon/trace/trace.h
@@ -19,7 +19,7 @@ public:
 
     static void DoTrace(const wchar_t *sender, const wchar_t *message);
 
-	static void RegisterSink(ITraceSink *sink);
+    static void RegisterSink(ITraceSink *sink);
 
     static bool HasSink();
 

--- a/src/libcommon/trace/trace.h
+++ b/src/libcommon/trace/trace.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "itracesink.h"
+#include <string>
+#include <cstdint>
+
+#ifdef _DEBUG
+#define TRACING_ENABLED 1
+#else
+#define TRACING_ENABLED 0
+#endif
+
+namespace common::trace
+{
+
+class Trace
+{
+public:
+
+    static void DoTrace(const wchar_t *sender, const wchar_t *message);
+
+	static void RegisterSink(ITraceSink *sink);
+
+    static bool HasSink();
+
+private:
+
+    static const uint32_t TAG_VALUE = 0xCAFEBABE;
+
+    static ITraceSink *Sink();
+
+    static std::wstring SinkKey();
+};
+
+}

--- a/src/libcommon/trace/xtrace.h
+++ b/src/libcommon/trace/xtrace.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include "trace.h"
+#include "libcommon/macroargument.h"
+#include <sstream>
+
+#if TRACING_ENABLED == 1
+
+#define XTRACE(...) VFUNC(XTRACE, __VA_ARGS__)
+
+#define XTRACE1(a)\
+{\
+std::wstringstream xtrace_ss;\
+xtrace_ss << a;\
+common::trace::Trace::DoTrace(__FUNCTIONW__, xtrace_ss.str().c_str());\
+}
+
+#define XTRACE2(a, b)\
+{\
+std::wstringstream xtrace_ss;\
+xtrace_ss << a << b;\
+common::trace::Trace::DoTrace(__FUNCTIONW__, xtrace_ss.str().c_str());\
+}
+
+#define XTRACE3(a, b, c)\
+{\
+std::wstringstream xtrace_ss;\
+xtrace_ss << a << b << c;\
+common::trace::Trace::DoTrace(__FUNCTIONW__, xtrace_ss.str().c_str());\
+}
+
+#define XTRACE4(a, b, c, d)\
+{\
+std::wstringstream xtrace_ss;\
+xtrace_ss << a << b << c << d;\
+common::trace::Trace::DoTrace(__FUNCTIONW__, xtrace_ss.str().c_str());\
+}
+
+#define XTRACE5(a, b, c, d, e)\
+{\
+std::wstringstream xtrace_ss;\
+xtrace_ss << a << b << c << d << e;\
+common::trace::Trace::DoTrace(__FUNCTIONW__, xtrace_ss.str().c_str());\
+}
+
+#define XTRACE6(a, b, c, d, e, f)\
+{\
+std::wstringstream xtrace_ss;\
+xtrace_ss << a << b << c << d << e << f;\
+common::trace::Trace::DoTrace(__FUNCTIONW__, xtrace_ss.str().c_str());\
+}
+
+#define XTRACE7(a, b, c, d, e, f, g)\
+{\
+std::wstringstream xtrace_ss;\
+xtrace_ss << a << b << c << d << e << f << g;\
+common::trace::Trace::DoTrace(__FUNCTIONW__, xtrace_ss.str().c_str());\
+}
+
+#define XTRACE8(a, b, c, d, e, f, g, h)\
+{\
+std::wstringstream xtrace_ss;\
+xtrace_ss << a << b << c << d << e << f << g << h;\
+common::trace::Trace::DoTrace(__FUNCTIONW__, xtrace_ss.str().c_str());\
+}
+
+#define XTRACE9(a, b, c, d, e, f, g, h, i)\
+{\
+std::wstringstream xtrace_ss;\
+xtrace_ss << a << b << c << d << e << f << g << h << i;\
+common::trace::Trace::DoTrace(__FUNCTIONW__, xtrace_ss.str().c_str());\
+}
+
+#define XTRACE10(a, b, c, d, e, f, g, h, i, j)\
+{\
+std::wstringstream xtrace_ss;\
+xtrace_ss << a << b << c << d << e << f << g << h << i << j;\
+common::trace::Trace::DoTrace(__FUNCTIONW__, xtrace_ss.str().c_str());\
+}
+
+#else
+#define XTRACE(...)
+#endif


### PR DESCRIPTION
Adds functionality to enable debug tracing.

I've built a solution where different instances of libcommon, within the same process, can hook up to the same tracer sink. This is mostly safe but could cause problems e.g. if an old version of libcommon first registers the sink, and a more recent version of libcommon, built with a newer compiler/other settings, tries to use the sink.

A safer and more straight-forward alternative would be to keep the various instances of libcommon isolated. The major limitation with this approach is that the different instances cannot easily coordinate tracing (write to the same file).