### PR TITLE
Fix COM deinit

### DIFF
--- a/src/libcommon/libcommon.vcxproj
+++ b/src/libcommon/libcommon.vcxproj
@@ -82,6 +82,7 @@
     <ClInclude Include="trace\itracesink.h" />
     <ClInclude Include="trace\trace.h" />
     <ClInclude Include="trace\xtrace.h" />
+    <ClInclude Include="valuemapper.h" />
     <ClInclude Include="wmi\connection.h" />
     <ClInclude Include="wmi\eventdispatcher.h" />
     <ClInclude Include="wmi\iconnection.h" />

--- a/src/libcommon/libcommon.vcxproj.filters
+++ b/src/libcommon/libcommon.vcxproj.filters
@@ -137,6 +137,7 @@
     <ClInclude Include="registry\registrypath.h">
       <Filter>registry</Filter>
     </ClInclude>
+    <ClInclude Include="valuemapper.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="wmi">

--- a/src/libcommon/valuemapper.h
+++ b/src/libcommon/valuemapper.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <algorithm>
+#include <utility>
+#include <vector>
+#include <stdexcept>
+#include <initializer_list>
+
+namespace common
+{
+
+template<typename T, typename U>
+class ValueMapper
+{
+public:
+
+	using value_type = std::pair<T, U>;
+
+	ValueMapper(std::initializer_list<value_type> values)
+	{
+		m_values.reserve(values.size());
+		std::copy(values.begin(), values.end(), std::back_inserter(m_values));
+	}
+
+	U map(T t) const
+	{
+		auto it = std::find_if(m_values.begin(), m_values.end(), [&t](const value_type &tuple)
+		{
+			return t == tuple.first;
+		});
+
+		if (m_values.end() == it)
+		{
+			throw std::runtime_error("Could not map between values");
+		}
+
+		return it->second;
+	}
+
+private:
+
+	std::vector<value_type> m_values;
+};
+
+}

--- a/src/libcommon/wmi/connection.h
+++ b/src/libcommon/wmi/connection.h
@@ -26,6 +26,8 @@ public:
 
 	explicit Connection(Namespace ns);
 
+	~Connection();
+
 	ResultSet query(const wchar_t *query) override;
 
 	CComPtr<IWbemServices> services() override
@@ -35,10 +37,14 @@ public:
 
 private:
 
+	bool m_unloadApartment;
+
 	CComPtr<IWbemLocator> m_locator;
 	CComPtr<IWbemServices> m_services;
 
 	_bstr_t m_queryLanguage;
+
+	void releaseComResources();
 };
 
 }


### PR DESCRIPTION
Fixed ctor on `common::wmi::Connection`.  It now tracks whether we initialize/up the reference count on the multithreaded COM apartment. Ensure proper clean up in ctor if there are errors.

Also added dtor on the same class, to ensure orderly destruction of COM instances and deinit of COM.

Added generic "value mapper" to avoid using a switch statement in various locations and perform the mapping ad-hoc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-libraries/9)
<!-- Reviewable:end -->
