### PR TITLE
Correct params to WriteFile call

### DIFF
--- a/src/libcommon/trace/filetracesink.cpp
+++ b/src/libcommon/trace/filetracesink.cpp
@@ -37,7 +37,9 @@ void FileTraceSink::trace(const wchar_t *sender, const wchar_t *message)
 	auto msg = std::wstring(sender).append(L": ").append(message).append(L"\xd\xa");
 	auto encoded = common::string::ToAnsi(msg);
 
-	if (FALSE == WriteFile(m_file, encoded.c_str(), static_cast<DWORD>(encoded.size()), nullptr, nullptr))
+	DWORD bytesWritten;
+
+	if (FALSE == WriteFile(m_file, encoded.c_str(), static_cast<DWORD>(encoded.size()), &bytesWritten, nullptr))
 	{
 		THROW_GLE("Failed to write trace event to disk");
 	}


### PR DESCRIPTION
Was calling the API incorrectly and it was working great on Win10. I always forget if this parameter is optional or not. Well, this commit fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-libraries/12)
<!-- Reviewable:end -->
