### PR TITLE
Add Join function and support for REG_EXPAND_SZ keys

### DIFF
--- a/src/libcommon/registry/registrykey.h
+++ b/src/libcommon/registry/registrykey.h
@@ -20,6 +20,7 @@ public:
 	RegistryKey &operator=(const RegistryKey &rhs) = delete;
 
 	void writeValue(const std::wstring &valueName, const std::wstring &valueData);
+	void writeValueExpanded(const std::wstring &valueName, const std::wstring &valueData);
 	void writeValue(const std::wstring &valueName, uint32_t valueData);
 	void writeValue(const std::wstring &valueName, uint64_t valueData);
 	void writeValue(const std::wstring &valueName, const std::vector<uint8_t> &valueData);

--- a/src/libcommon/registry/registrykey.h
+++ b/src/libcommon/registry/registrykey.h
@@ -21,11 +21,11 @@ public:
 
 	enum class ValueStringType
 	{
-		SZ = REG_SZ,
-		EXPAND_SZ = REG_EXPAND_SZ,
+		RegularString = REG_SZ,
+		ExpandableString = REG_EXPAND_SZ,
 	};
 
-	void writeValue(const std::wstring &valueName, const std::wstring &valueData, ValueStringType type = ValueStringType::SZ);
+	void writeValue(const std::wstring &valueName, const std::wstring &valueData, ValueStringType type = ValueStringType::RegularString);
 	void writeValue(const std::wstring &valueName, uint32_t valueData);
 	void writeValue(const std::wstring &valueName, uint64_t valueData);
 	void writeValue(const std::wstring &valueName, const std::vector<uint8_t> &valueData);
@@ -33,7 +33,7 @@ public:
 
 	void deleteValue(const std::wstring &valueName);
 
-	std::wstring readString(const std::wstring &valueName, ValueStringType type = ValueStringType::SZ) const;
+	std::wstring readString(const std::wstring &valueName, ValueStringType type = ValueStringType::RegularString) const;
 	uint32_t readUint32(const std::wstring &valueName) const;
 	uint64_t readUint64(const std::wstring &valueName) const;
 	std::vector<uint8_t> readBinaryBlob(const std::wstring &valueName) const;

--- a/src/libcommon/registry/registrykey.h
+++ b/src/libcommon/registry/registrykey.h
@@ -19,8 +19,13 @@ public:
 	RegistryKey(const RegistryKey &rhs) = delete;
 	RegistryKey &operator=(const RegistryKey &rhs) = delete;
 
-	void writeValue(const std::wstring &valueName, const std::wstring &valueData);
-	void writeValueExpanded(const std::wstring &valueName, const std::wstring &valueData);
+	enum class ValueStringType
+	{
+		SZ = REG_SZ,
+		EXPAND_SZ = REG_EXPAND_SZ,
+	};
+
+	void writeValue(const std::wstring &valueName, const std::wstring &valueData, ValueStringType type = ValueStringType::SZ);
 	void writeValue(const std::wstring &valueName, uint32_t valueData);
 	void writeValue(const std::wstring &valueName, uint64_t valueData);
 	void writeValue(const std::wstring &valueName, const std::vector<uint8_t> &valueData);
@@ -28,7 +33,7 @@ public:
 
 	void deleteValue(const std::wstring &valueName);
 
-	std::wstring readString(const std::wstring &valueName) const;
+	std::wstring readString(const std::wstring &valueName, ValueStringType type = ValueStringType::SZ) const;
 	uint32_t readUint32(const std::wstring &valueName) const;
 	uint64_t readUint64(const std::wstring &valueName) const;
 	std::vector<uint8_t> readBinaryBlob(const std::wstring &valueName) const;

--- a/src/libcommon/string.cpp
+++ b/src/libcommon/string.cpp
@@ -47,7 +47,7 @@ std::wstring FormatSid(const SID &sid)
 	return formatted;
 }
 
-std::wstring Join(const std::vector<std::wstring> &parts)
+std::wstring Join(const std::vector<std::wstring> &parts, const std::wstring &delimiter)
 {
 	switch (parts.size())
 	{
@@ -61,18 +61,18 @@ std::wstring Join(const std::vector<std::wstring> &parts)
 
 			size_t reserveSize = 0;
 
-			std::for_each(parts.begin(), parts.end(), [&reserveSize](const std::wstring &part)
+			std::for_each(parts.begin(), parts.end(), [&reserveSize, &delimiter](const std::wstring &part)
 			{
-				reserveSize += (part.size() + 2);
+				reserveSize += (part.size() + delimiter.size());
 			});
 
 			joined.reserve(reserveSize);
 
-			std::for_each(parts.begin(), parts.end(), [&joined](const std::wstring &part)
+			std::for_each(parts.begin(), parts.end(), [&joined, &delimiter](const std::wstring &part)
 			{
 				if (!joined.empty())
 				{
-					joined.append(L", ");
+					joined.append(delimiter);
 				}
 
 				joined.append(part);
@@ -182,17 +182,6 @@ std::wstring Lower(const std::wstring &str)
 	_wcslwr_s(buffer.get(), bufferSize);
 
 	return buffer.get();
-}
-
-std::wstring Join(const std::vector<std::wstring> &tokens, const std::wstring &delimiter)
-{
-	std::wstringstream ss;
-	if (tokens.size() >= 1)
-		ss << tokens[0];
-	for (int i = 1; i < tokens.size(); i++) {
-		ss << delimiter << tokens[i];
-	}
-	return ss.str();
 }
 
 std::vector<std::wstring> Tokenize(const std::wstring &str, const std::wstring &delimiters)

--- a/src/libcommon/string.cpp
+++ b/src/libcommon/string.cpp
@@ -184,6 +184,17 @@ std::wstring Lower(const std::wstring &str)
 	return buffer.get();
 }
 
+std::wstring Join(const std::vector<std::wstring> &tokens, const std::wstring &delimiter)
+{
+	std::wstringstream ss;
+	if (tokens.size() >= 1)
+		ss << tokens[0];
+	for (int i = 1; i < tokens.size(); i++) {
+		ss << delimiter << tokens[i];
+	}
+	return ss.str();
+}
+
 std::vector<std::wstring> Tokenize(const std::wstring &str, const std::wstring &delimiters)
 {
 	auto bufferSize = str.size() + 1;

--- a/src/libcommon/string.h
+++ b/src/libcommon/string.h
@@ -12,7 +12,7 @@ namespace common::string {
 
 std::wstring FormatGuid(const GUID &guid);
 std::wstring FormatSid(const SID &sid);
-std::wstring Join(const std::vector<std::wstring> &parts);
+std::wstring Join(const std::vector<std::wstring> &parts, const std::wstring &delimiter=L", ");
 
 template<typename T>
 std::wstring FormatFlags(std::vector<std::pair<T, std::wstring> > &definitions, T flags)
@@ -66,7 +66,6 @@ bool BeginsWith(const std::basic_string<T> &hay, const std::basic_string<T> &nee
 }
 
 std::wstring Lower(const std::wstring &str);
-std::wstring Join(const std::vector<std::wstring>& tokens, const std::wstring &delimiter);
 std::vector<std::wstring> Tokenize(const std::wstring &str, const std::wstring &delimiters);
 std::string ToAnsi(const std::wstring &str);
 std::wstring ToWide(const std::string &str);

--- a/src/libcommon/string.h
+++ b/src/libcommon/string.h
@@ -66,6 +66,7 @@ bool BeginsWith(const std::basic_string<T> &hay, const std::basic_string<T> &nee
 }
 
 std::wstring Lower(const std::wstring &str);
+std::wstring Join(const std::vector<std::wstring>& tokens, const std::wstring &delimiter);
 std::vector<std::wstring> Tokenize(const std::wstring &str, const std::wstring &delimiters);
 std::string ToAnsi(const std::wstring &str);
 std::wstring ToWide(const std::string &str);


### PR DESCRIPTION
A couple of updates used by the winpathfix branch in mullvadvpn-app:
* Read and write to REG_EXPAND_SZ keys with RegistryKey. (Though `::writeValueExpanded()` doesn't seem like the cleanest solution.)
* Added a Join function for strings that lets you choose a delimiter string to use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-libraries/17)
<!-- Reviewable:end -->
