### PR TITLE
Upgrade Windows SDK and platform toolset

### DIFF
--- a/src/libcommon/fileenumerator.cpp
+++ b/src/libcommon/fileenumerator.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "fileenumerator.h"
 #include "filesystem.h"
-#include <experimental/filesystem>
+#include <filesystem>
 
 namespace common::fs
 {
@@ -14,7 +14,7 @@ FileEnumerator::FileEnumerator(const std::wstring &directory)
 FileEnumerator::FileEnumerator(const std::wstring &directory, const std::wstring objectMask)
 	: m_directory(directory)
 {
-	const auto findspec = std::experimental::filesystem::path(directory).append(objectMask);
+	const auto findspec = std::filesystem::path(directory).append(objectMask);
 
 	m_enumHandle = FindFirstFileW
 	(

--- a/src/libcommon/libcommon.vcxproj
+++ b/src/libcommon/libcommon.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="16.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -89,36 +89,36 @@
     <ClInclude Include="valuemapper.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <VCProjectVersion>15.0</VCProjectVersion>
+    <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{B52E2D10-A94A-4605-914A-2DCEF6A757EF}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>libcommon</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/src/libcommon/process.cpp
+++ b/src/libcommon/process.cpp
@@ -2,7 +2,7 @@
 #include "process.h"
 #include "error.h"
 #include <stdexcept>
-#include <experimental/filesystem>
+#include <filesystem>
 
 #define PSAPI_VERSION 2
 #include <psapi.h>
@@ -105,9 +105,7 @@ std::unordered_set<DWORD> GetAllProcessIdsFromName(const std::wstring &processNa
 
 void Run(const std::wstring &path)
 {
-	using namespace std::experimental;
-
-	const auto fspath = filesystem::path(path);
+	const auto fspath = std::filesystem::path(path);
 
 	if (false == fspath.is_absolute()
 		|| false == fspath.has_filename())
@@ -132,9 +130,7 @@ void Run(const std::wstring &path)
 
 void RunInContext(HANDLE securityContext, const std::wstring &path)
 {
-	using namespace std::experimental;
-
-	const auto fspath = filesystem::path(path);
+	const auto fspath = std::filesystem::path(path);
 
 	if (false == fspath.is_absolute()
 		|| false == fspath.has_filename())

--- a/src/libcommon/trace/filetracesink.cpp
+++ b/src/libcommon/trace/filetracesink.cpp
@@ -3,14 +3,14 @@
 #include "libcommon/filesystem.h"
 #include "libcommon/string.h"
 #include "libcommon/error.h"
-#include <experimental/filesystem>
+#include <filesystem>
 
 namespace common::trace
 {
 
 FileTraceSink::FileTraceSink(const std::wstring &file)
 {
-	const auto path = std::experimental::filesystem::path(file).parent_path();
+	const auto path = std::filesystem::path(file).parent_path();
 
 	common::fs::Mkdir(path);
 

--- a/src/test-libcommon/test-libcommon.vcxproj
+++ b/src/test-libcommon/test-libcommon.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="16.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -19,36 +19,36 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <VCProjectVersion>15.0</VCProjectVersion>
+    <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{6EC5EDAE-0EEB-49E1-B234-0A896969F030}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>testlibcommon</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/windows-libraries.sln
+++ b/windows-libraries.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2027
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29324.140
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libcommon", "src\libcommon\libcommon.vcxproj", "{B52E2D10-A94A-4605-914A-2DCEF6A757EF}"
 EndProject


### PR DESCRIPTION
`std::experimental::filesystem` was also replaced with `std::filesystem`. It compiles with Visual Studio 2019 now.

Cf. https://github.com/mullvad/mullvadvpn-app/pull/1231

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-libraries/18)
<!-- Reviewable:end -->
