### PR TITLE
Supportive code for WireGuard

### DIFF
--- a/src/libcommon/burstguard.cpp
+++ b/src/libcommon/burstguard.cpp
@@ -1,0 +1,135 @@
+#include "stdafx.h"
+#include "burstguard.h"
+#include <process.h>
+#include <libcommon/error.h>
+
+namespace common
+{
+
+BurstGuard::BurstGuard(Callback callback, uint32_t burstDuration, uint32_t interferenceInterval)
+	: m_callback(callback)
+	, m_burstDuration(burstDuration)
+	, m_interferenceInterval(interferenceInterval)
+	, m_timestampBurstStart(0)
+	, m_threadState(ThreadState::Sleeping)
+{
+	m_stateEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+
+	THROW_GLE_IF(NULL, m_stateEvent, "Create BurstGuard thread state event object");
+
+	const auto t = _beginthreadex(nullptr, 0, BurstGuard::Thread, this, 0, nullptr);
+
+	if (0 == t)
+	{
+		CloseHandle(m_stateEvent);
+		throw std::runtime_error("Failed to create BurstGuard thread");
+	}
+
+	m_thread = reinterpret_cast<HANDLE>(t);
+}
+
+BurstGuard::~BurstGuard()
+{
+	{
+		std::scoped_lock<std::mutex> lock(m_mutex);
+
+		m_threadState = ThreadState::Exiting;
+		SetEvent(m_stateEvent);
+	}
+
+	WaitForSingleObject(m_thread, INFINITE);
+
+	CloseHandle(m_thread);
+	CloseHandle(m_stateEvent);
+}
+
+void BurstGuard::trigger()
+{
+	std::scoped_lock<std::mutex> lock(m_mutex);
+
+	const uint64_t timestampNow = static_cast<uint64_t>(GetTickCount64());
+
+	if (0 == m_timestampBurstStart)
+	{
+		m_timestampBurstStart = timestampNow;
+	}
+	else if (0 != m_interferenceInterval
+		&& timestampNow - m_timestampBurstStart >= m_interferenceInterval)
+	{
+		m_callback();
+		m_timestampBurstStart = 0;
+
+		m_threadState = ThreadState::Sleeping;
+		SetEvent(m_stateEvent);
+
+		return;
+	}
+
+	//
+	// Reset timer.
+	//
+
+	m_threadState = ThreadState::WaitingBurstEnd;
+	SetEvent(m_stateEvent);
+}
+
+//static
+unsigned __stdcall BurstGuard::Thread(void *context)
+{
+	reinterpret_cast<BurstGuard *>(context)->thread();
+	return 0;
+}
+
+void BurstGuard::thread()
+{
+	for (;;)
+	{
+		WaitForSingleObject(m_stateEvent, INFINITE);
+
+ack_and_process:
+
+		ThreadState state;
+
+		{
+			std::scoped_lock<std::mutex> lock(m_mutex);
+
+			ResetEvent(m_stateEvent);
+			state = m_threadState;
+		}
+
+		if (ThreadState::Sleeping == state)
+		{
+			continue;
+		}
+
+		if (ThreadState::Exiting == state)
+		{
+			break;
+		}
+
+		//
+		// Wait for burst to end.
+		//
+
+		if (WAIT_TIMEOUT != WaitForSingleObject(m_stateEvent, m_burstDuration))
+		{
+			goto ack_and_process;
+		}
+
+		//
+		// Burst has ended.
+		//
+
+		{
+			std::scoped_lock<std::mutex> lock(m_mutex);
+
+			if (0 != m_timestampBurstStart)
+			{
+				m_callback();
+				m_timestampBurstStart = 0;
+			}
+		}
+	}
+}
+
+}

--- a/src/libcommon/burstguard.h
+++ b/src/libcommon/burstguard.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <windows.h>
+#include <functional>
+#include <mutex>
+#include <thread>
+
+namespace common
+{
+
+class BurstGuard
+{
+public:
+
+	using Callback = std::function<void()>;
+
+	//
+	// `burstDuration`
+	// Requests to trigger the callback are clumped together if occuring within this timeframe.
+	// The value is specified in milliseconds.
+	//
+	// `interferenceInterval`
+	// For extended periods of bursts you may want to call through to the callback even
+	// though the burst is still on-going.
+	// The value is specified in milliseconds.
+	// If specified as 0, it means interference is disabled.
+	//
+	BurstGuard(Callback callback, uint32_t burstDuration, uint32_t interferenceInterval = 0);
+	~BurstGuard();
+
+	BurstGuard(const BurstGuard &) = delete;
+	BurstGuard &operator=(const BurstGuard &) = delete;
+	BurstGuard(BurstGuard &&) = delete;
+	BurstGuard &operator=(BurstGuard &&) = delete;
+
+	void trigger();
+
+private:
+
+	Callback m_callback;
+	uint32_t m_burstDuration;
+	uint32_t m_interferenceInterval;
+
+	std::mutex m_mutex;
+	uint64_t m_timestampBurstStart;
+
+	enum ThreadState
+	{
+		Sleeping,
+		WaitingBurstEnd,
+		Exiting,
+	};
+
+	ThreadState m_threadState;
+	HANDLE m_stateEvent;
+	HANDLE m_thread;
+
+	static unsigned __stdcall Thread(void *context);
+	void thread();
+};
+
+}

--- a/src/libcommon/libcommon.vcxproj
+++ b/src/libcommon/libcommon.vcxproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <ClCompile Include="applicationrunner.cpp" />
     <ClCompile Include="binarycomposer.cpp" />
+    <ClCompile Include="burstguard.cpp" />
     <ClCompile Include="com.cpp" />
     <ClCompile Include="error.cpp" />
     <ClCompile Include="fileenumerator.cpp" />
@@ -28,6 +29,7 @@
     <ClCompile Include="guid.cpp" />
     <ClCompile Include="logging\logsink.cpp" />
     <ClCompile Include="network.cpp" />
+    <ClCompile Include="network\adapters.cpp" />
     <ClCompile Include="process.cpp" />
     <ClCompile Include="registry\registry.cpp" />
     <ClCompile Include="registry\registrykey.cpp" />
@@ -52,6 +54,7 @@
     <ClInclude Include="applicationrunner.h" />
     <ClInclude Include="binarycomposer.h" />
     <ClInclude Include="buffer.h" />
+    <ClInclude Include="burstguard.h" />
     <ClInclude Include="com.h" />
     <ClInclude Include="error.h" />
     <ClInclude Include="fileenumerator.h" />
@@ -63,6 +66,7 @@
     <ClInclude Include="math.h" />
     <ClInclude Include="memory.h" />
     <ClInclude Include="network.h" />
+    <ClInclude Include="network\adapters.h" />
     <ClInclude Include="process.h" />
     <ClInclude Include="registry\registry.h" />
     <ClInclude Include="registry\registrykey.h" />

--- a/src/libcommon/libcommon.vcxproj.filters
+++ b/src/libcommon/libcommon.vcxproj.filters
@@ -44,6 +44,10 @@
     <ClCompile Include="logging\logsink.cpp">
       <Filter>logging</Filter>
     </ClCompile>
+    <ClCompile Include="network\adapters.cpp">
+      <Filter>network</Filter>
+    </ClCompile>
+    <ClCompile Include="burstguard.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="applicationrunner.h" />
@@ -108,6 +112,10 @@
     <ClInclude Include="logging\logsink.h">
       <Filter>logging</Filter>
     </ClInclude>
+    <ClInclude Include="network\adapters.h">
+      <Filter>network</Filter>
+    </ClInclude>
+    <ClInclude Include="burstguard.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="serialization">
@@ -121,6 +129,9 @@
     </Filter>
     <Filter Include="logging">
       <UniqueIdentifier>{dcae1c72-8215-4a52-a099-11aa3f770b4b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="network">
+      <UniqueIdentifier>{cdd9835f-e016-46fa-bdb4-847181ac118d}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/src/libcommon/network/adapters.cpp
+++ b/src/libcommon/network/adapters.cpp
@@ -1,0 +1,86 @@
+#include "stdafx.h"
+#include "adapters.h"
+#include "libcommon/error.h"
+#include <sstream>
+#include <stdexcept>
+
+namespace common::network
+{
+
+const IP_ADAPTER_ADDRESSES *Adapters::next() const
+{
+	if (nullptr == m_currentEntry)
+	{
+		return nullptr;
+	}
+
+	auto entry = m_currentEntry;
+	m_currentEntry = m_currentEntry->Next;
+
+	return entry;
+}
+
+Adapters::Adapters(DWORD family, DWORD flags)
+{
+	std::vector<uint8_t> buffer;
+
+	static const size_t MSDN_RECOMMENDED_STARTING_BUFFER_SIZE = 1024 * 15;
+	buffer.resize(MSDN_RECOMMENDED_STARTING_BUFFER_SIZE);
+
+	ULONG bufferSize = static_cast<ULONG>(buffer.size());
+	auto bufferPointer = reinterpret_cast<IP_ADAPTER_ADDRESSES *>(&buffer[0]);
+
+	//
+	// Acquire interfaces.
+	//
+
+	for (;;)
+	{
+		const auto status = GetAdaptersAddresses(family, flags, nullptr, bufferPointer, &bufferSize);
+
+		if (ERROR_SUCCESS == status)
+		{
+			break;
+		}
+
+		if (ERROR_NO_DATA == status)
+		{
+			m_buffer.clear();
+			m_currentEntry = nullptr;
+
+			return;
+		}
+
+		THROW_UNLESS(ERROR_BUFFER_OVERFLOW, status, "Probe required buffer size for GetAdaptersAddresses");
+
+		buffer.resize(bufferSize);
+		bufferPointer = reinterpret_cast<IP_ADAPTER_ADDRESSES *>(&buffer[0]);
+	}
+
+	//
+	// Verify structure compatibility.
+	// The structure has been extended many times.
+	//
+
+	const auto systemSize = bufferPointer->Length;
+	const auto codeSize = sizeof(IP_ADAPTER_ADDRESSES);
+
+	if (systemSize < codeSize)
+	{
+		std::stringstream ss;
+
+		ss << "Expecting IP_ADAPTER_ADDRESSES to have size " << codeSize << " bytes. "
+			<< "Found structure with size " << systemSize << " bytes.";
+
+		throw std::runtime_error(ss.str());
+	}
+
+	//
+	// Initialize members.
+	//
+
+	m_buffer = std::move(buffer);
+	reset();
+}
+
+}

--- a/src/libcommon/network/adapters.h
+++ b/src/libcommon/network/adapters.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <vector>
+#include <winsock2.h>
+#include <windows.h>
+#include <iphlpapi.h>
+
+//
+// This is a thin wrapper on top of GetAdaptersAddresses()
+// in order to simplify memory management.
+//
+
+namespace common::network
+{
+
+class Adapters
+{
+	std::vector<uint8_t> m_buffer;
+	mutable const IP_ADAPTER_ADDRESSES *m_currentEntry;
+
+public:
+
+	Adapters(const Adapters &) = delete;
+	Adapters &operator=(const Adapters &) = delete;
+
+	Adapters(Adapters &&rhs)
+		: m_buffer(std::move(rhs.m_buffer))
+		, m_currentEntry(rhs.m_currentEntry)
+	{
+	}
+
+	Adapters(DWORD family, DWORD flags);
+
+	const IP_ADAPTER_ADDRESSES *next() const;
+
+	void reset() const
+	{
+		if (false == m_buffer.empty())
+		{
+			m_currentEntry = reinterpret_cast<const IP_ADAPTER_ADDRESSES *>(&m_buffer[0]);
+		}
+	}
+};
+
+}


### PR DESCRIPTION
`BurstGuard` is used to protect computationally expensive code paths from being activated excessively.

`Adapters` is a thin wrapper around `GetAdaptersAddresses()` that simplifies memory management.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-libraries/19)
<!-- Reviewable:end -->
