### PR TITLE
Correct code that implements throwing/throwing nested

### DIFF
--- a/src/libcommon/error.cpp
+++ b/src/libcommon/error.cpp
@@ -63,7 +63,12 @@ void Throw(const char *operation, DWORD errorCode)
 
 	ss << operation << ": " << common::error::FormatWindowsErrorPlain(errorCode);
 
-	std::throw_with_nested(std::runtime_error(ss.str()));
+	if (std::current_exception())
+	{
+		std::throw_with_nested(std::runtime_error(ss.str()));
+	}
+
+	throw std::runtime_error(ss.str());
 }
 
 void UnwindException(const std::exception &err, std::shared_ptr<common::logging::ILogSink> logSink)


### PR DESCRIPTION
Apparently `std::throw_with_nested` is not smart enough to throw a regular exception when there is not currently an active exception.

It instead nests a null exception which cannot be properly unwound, and everything breaks. It could probably be unwound if catching by pointer, which we're not going to be doing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-libraries/22)
<!-- Reviewable:end -->
