### PR TITLE
Update exception macros

### DIFF
--- a/src/libcommon/error.h
+++ b/src/libcommon/error.h
@@ -6,27 +6,43 @@
 #include <memory>
 #include <windows.h>
 
+#define THROW_IF(unwanted, actual, operation)\
+if(actual == unwanted)\
+{\
+	::common::error::Throw(operation, actual, __FILE__, __LINE__);\
+}\
+
 #define THROW_UNLESS(expected, actual, operation)\
 if(actual != expected)\
 {\
-	::common::error::Throw(operation, actual);\
+	::common::error::Throw(operation, actual, __FILE__, __LINE__);\
 }\
 
 #define THROW_GLE_UNLESS(expected, actual, operation)\
 if(actual != expected)\
 {\
-	::common::error::Throw(operation, GetLastError());\
+	::common::error::Throw(operation, GetLastError(), __FILE__, __LINE__);\
 }\
 
 #define THROW_GLE_IF(unwanted, actual, operation)\
 if(actual == unwanted)\
 {\
-	::common::error::Throw(operation, GetLastError());\
+	::common::error::Throw(operation, GetLastError(), __FILE__, __LINE__);\
 }\
 
 #define THROW_GLE(operation)\
 {\
-	::common::error::Throw(operation, GetLastError());\
+	::common::error::Throw(operation, GetLastError(), __FILE__, __LINE__);\
+}\
+
+#define THROW_UNCONDITIONALLY(operation)\
+{\
+	::common::error::Throw(operation, __FILE__, __LINE__);\
+}\
+
+#define THROW_WITH_CODE(operation, code)\
+{\
+	::common::error::Throw(operation, code, __FILE__, __LINE__);\
 }\
 
 namespace common::error {
@@ -34,7 +50,8 @@ namespace common::error {
 std::wstring FormatWindowsError(DWORD errorCode);
 std::string FormatWindowsErrorPlain(DWORD errorCode);
 
-__declspec(noreturn) void Throw(const char *operation, DWORD errorCode);
+[[noreturn]] void Throw(const char *operation, DWORD errorCode, const char *file, size_t line);
+[[noreturn]] void Throw(const char *operation, const char *file, size_t line);
 
 void UnwindException(const std::exception &err, std::shared_ptr<common::logging::ILogSink> logSink);
 

--- a/src/libcommon/registry/registry.cpp
+++ b/src/libcommon/registry/registry.cpp
@@ -105,7 +105,7 @@ void Registry::DeleteKey(HKEY key, const std::wstring &subkey, RegistryView view
 	if (ERROR_SUCCESS != status
 		&& ERROR_FILE_NOT_FOUND != status)
 	{
-		common::error::Throw("Delete registry key", status);
+		THROW_WITH_CODE("Delete registry key", status);
 	}
 }
 
@@ -138,7 +138,7 @@ void Registry::DeleteTree(HKEY key, const std::wstring &subkey, RegistryView vie
 	if (ERROR_SUCCESS != status
 		&& ERROR_FILE_NOT_FOUND != status)
 	{
-		common::error::Throw("Delete registry tree", status);
+		THROW_WITH_CODE("Delete registry tree", status);
 	}
 }
 

--- a/src/libcommon/security.cpp
+++ b/src/libcommon/security.cpp
@@ -30,7 +30,7 @@ void AdjustTokenPrivilege(HANDLE token, const std::wstring &privilege, bool enab
 	//
 	if (FALSE == status || ERROR_SUCCESS != error)
 	{
-		common::error::Throw("Adjust token privileges", error);
+		THROW_WITH_CODE("Adjust token privileges", error);
 	}
 }
 

--- a/src/libcommon/trace/filetracesink.cpp
+++ b/src/libcommon/trace/filetracesink.cpp
@@ -21,7 +21,7 @@ FileTraceSink::FileTraceSink(const std::wstring &file)
 		const auto error = GetLastError();
 		const auto msg = std::string("Failed to create trace file: ").append(common::string::ToAnsi(file));
 
-		common::error::Throw(msg.c_str(), error);
+		THROW_WITH_CODE(msg.c_str(), error);
 	}
 }
 


### PR DESCRIPTION
Complemented with more macros so there is never a reason to call `common::error::Throw()` directly.

Updated all macros to include the file and line number where the thrown exception originates.

The only thing I'm wondering about is the predefined `__FILE__` macro, which in our case expands to the filename including absolute path. It's a bit long and redundant? It would be easy to search the string for only the filename and include only that in the final message.

One the other hand, the file name alone may not be unique enough.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-libraries/25)
<!-- Reviewable:end -->
