### PR TITLE
More updates to exception macros and code that uses them

### DIFF
--- a/src/libcommon/burstguard.cpp
+++ b/src/libcommon/burstguard.cpp
@@ -15,14 +15,14 @@ BurstGuard::BurstGuard(Callback callback, uint32_t burstDuration, uint32_t inter
 {
 	m_stateEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
 
-	THROW_GLE_IF(NULL, m_stateEvent, "Create BurstGuard thread state event object");
+	THROW_GLE_IF(nullptr, m_stateEvent, "Create BurstGuard thread state event object");
 
 	const auto t = _beginthreadex(nullptr, 0, BurstGuard::Thread, this, 0, nullptr);
 
 	if (0 == t)
 	{
 		CloseHandle(m_stateEvent);
-		throw std::runtime_error("Failed to create BurstGuard thread");
+		THROW_UNCONDITIONALLY("Failed to create BurstGuard thread");
 	}
 
 	m_thread = reinterpret_cast<HANDLE>(t);

--- a/src/libcommon/error.h
+++ b/src/libcommon/error.h
@@ -6,26 +6,31 @@
 #include <memory>
 #include <windows.h>
 
-#define THROW_IF(unwanted, actual, operation)\
+#define THROW_CODE_IF(unwanted, actual, operation)\
 if(actual == unwanted)\
 {\
 	::common::error::Throw(operation, actual, __FILE__, __LINE__);\
 }\
 
-#define THROW_UNLESS(expected, actual, operation)\
+#define THROW_CODE_UNLESS(expected, actual, operation)\
 if(actual != expected)\
 {\
 	::common::error::Throw(operation, actual, __FILE__, __LINE__);\
 }\
 
-#define THROW_GLE_UNLESS(expected, actual, operation)\
-if(actual != expected)\
+#define THROW_CODE(code, operation)\
 {\
-	::common::error::Throw(operation, GetLastError(), __FILE__, __LINE__);\
+	::common::error::Throw(operation, code, __FILE__, __LINE__);\
 }\
 
 #define THROW_GLE_IF(unwanted, actual, operation)\
 if(actual == unwanted)\
+{\
+	::common::error::Throw(operation, GetLastError(), __FILE__, __LINE__);\
+}\
+
+#define THROW_GLE_UNLESS(expected, actual, operation)\
+if(actual != expected)\
 {\
 	::common::error::Throw(operation, GetLastError(), __FILE__, __LINE__);\
 }\
@@ -35,14 +40,21 @@ if(actual == unwanted)\
 	::common::error::Throw(operation, GetLastError(), __FILE__, __LINE__);\
 }\
 
-#define THROW_UNCONDITIONALLY(operation)\
+#define THROW_IF(unwanted, actual, operation)\
+if(actual == unwanted)\
 {\
 	::common::error::Throw(operation, __FILE__, __LINE__);\
 }\
 
-#define THROW_WITH_CODE(operation, code)\
+#define THROW_UNLESS(expected, actual, operation)\
+if(actual != expected)\
 {\
-	::common::error::Throw(operation, code, __FILE__, __LINE__);\
+	::common::error::Throw(operation, __FILE__, __LINE__);\
+}\
+
+#define THROW_UNCONDITIONALLY(operation)\
+{\
+	::common::error::Throw(operation, __FILE__, __LINE__);\
 }\
 
 namespace common::error {

--- a/src/libcommon/filesystem.cpp
+++ b/src/libcommon/filesystem.cpp
@@ -57,7 +57,7 @@ void Mkdir(const std::wstring &path)
 	{
 		auto msg = std::string("Failed to create directory: ").append(common::string::ToAnsi(target));
 
-		throw std::runtime_error(msg.c_str());
+		THROW_UNCONDITIONALLY(msg.c_str());
 	}
 }
 
@@ -67,16 +67,12 @@ std::wstring GetKnownFolderPath(REFKNOWNFOLDERID folderId, DWORD flags, HANDLE u
 
 	const auto status = SHGetKnownFolderPath(folderId, flags, userToken, &folder);
 
-	if (S_OK == status)
-	{
-		std::wstring result(folder);
+	THROW_UNLESS(S_OK, status, "Failed to retrieve \"known folder\" path");
 
-		CoTaskMemFree(folder);
+	std::wstring result(folder);
+	CoTaskMemFree(folder);
 
-		return result;
-	}
-
-	throw std::runtime_error("Failed to retrieve \"known folder\" path");
+	return result;
 }
 
 ScopedNativeFileSystem::ScopedNativeFileSystem()

--- a/src/libcommon/guid.cpp
+++ b/src/libcommon/guid.cpp
@@ -13,7 +13,7 @@ GUID Guid::Generate()
 
 	const auto status = UuidCreate(&u);
 
-	THROW_UNLESS(RPC_S_OK, status, "Generate GUID");
+	THROW_CODE_UNLESS(RPC_S_OK, status, "Generate GUID");
 
 	return u;
 }
@@ -25,7 +25,7 @@ GUID Guid::GenerateQuick()
 
 	const auto status = UuidCreateSequential(&u);
 
-	THROW_UNLESS(RPC_S_OK, status, "Generate GUID");
+	THROW_CODE_UNLESS(RPC_S_OK, status, "Generate GUID");
 
 	return u;
 }
@@ -61,7 +61,7 @@ GUID Guid::FromString(const std::wstring &guid)
 		}
 		default:
 		{
-			throw std::runtime_error("Invalid GUID format");
+			THROW_UNCONDITIONALLY("Invalid GUID format");
 		}
 	}
 
@@ -71,7 +71,7 @@ GUID Guid::FromString(const std::wstring &guid)
 
 	const auto status = UuidFromStringW(lolwindows, &convertedGuid);
 
-	THROW_UNLESS(RPC_S_OK, status, "Convert formatted GUID to raw representation");
+	THROW_CODE_UNLESS(RPC_S_OK, status, "Convert formatted GUID to raw representation");
 
 	return convertedGuid;
 }

--- a/src/libcommon/network/adapters.cpp
+++ b/src/libcommon/network/adapters.cpp
@@ -51,7 +51,7 @@ Adapters::Adapters(DWORD family, DWORD flags)
 			return;
 		}
 
-		THROW_UNLESS(ERROR_BUFFER_OVERFLOW, status, "Probe required buffer size for GetAdaptersAddresses");
+		THROW_CODE_UNLESS(ERROR_BUFFER_OVERFLOW, status, "Probe required buffer size for GetAdaptersAddresses");
 
 		buffer.resize(bufferSize);
 		bufferPointer = reinterpret_cast<IP_ADAPTER_ADDRESSES *>(&buffer[0]);
@@ -72,7 +72,7 @@ Adapters::Adapters(DWORD family, DWORD flags)
 		ss << "Expecting IP_ADAPTER_ADDRESSES to have size " << codeSize << " bytes. "
 			<< "Found structure with size " << systemSize << " bytes.";
 
-		throw std::runtime_error(ss.str());
+		THROW_UNCONDITIONALLY(ss.str().c_str());
 	}
 
 	//

--- a/src/libcommon/network/nci.cpp
+++ b/src/libcommon/network/nci.cpp
@@ -26,7 +26,7 @@ Nci::Nci()
 	if (nullptr == m_nciGetConnectionName)
 	{
 		FreeLibrary(m_dllHandle);
-		throw std::runtime_error("Failed to obtain pointer to NciGetConnectionName");
+		THROW_UNCONDITIONALLY("Failed to obtain pointer to NciGetConnectionName");
 	}
 
 	m_nciSetConnectionName = reinterpret_cast<nciSetConnectionNameFunc>(
@@ -35,7 +35,7 @@ Nci::Nci()
 	if (nullptr == m_nciSetConnectionName)
 	{
 		FreeLibrary(m_dllHandle);
-		throw std::runtime_error("Failed to obtain pointer to NciSetConnectionName");
+		THROW_UNCONDITIONALLY("Failed to obtain pointer to NciSetConnectionName");
 	}
 }
 
@@ -48,28 +48,28 @@ std::wstring Nci::getConnectionName(const GUID& guid) const
 {
 	DWORD nameLen = 0; // including L'\0'
 
-	if (0 != m_nciGetConnectionName(&guid, nullptr, 0, &nameLen))
-	{
-		throw std::runtime_error("NciGetConnectionName() failed");
-	}
+	THROW_UNLESS(0,
+		m_nciGetConnectionName(&guid, nullptr, 0, &nameLen),
+		"NciGetConnectionName() failed"
+	);
 
 	std::vector<wchar_t> buffer;
 	buffer.resize(nameLen / sizeof(wchar_t));
 
-	if (0 != m_nciGetConnectionName(&guid, &buffer[0], nameLen, nullptr))
-	{
-		throw std::runtime_error("NciGetConnectionName() failed");
-	}
+	THROW_UNLESS(0,
+		m_nciGetConnectionName(&guid, &buffer[0], nameLen, nullptr),
+		"NciGetConnectionName() failed"
+	);
 
 	return buffer.data();
 }
 
 void Nci::setConnectionName(const GUID& guid, const wchar_t* newName) const
 {
-	if (0 != m_nciSetConnectionName(&guid, newName))
-	{
-		throw std::runtime_error("NciSetConnectionName() failed");
-	}
+	THROW_UNLESS(0,
+		m_nciSetConnectionName(&guid, newName),
+		"NciSetConnectionName() failed"
+	);
 }
 
 }

--- a/src/libcommon/process/process.cpp
+++ b/src/libcommon/process/process.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "process.h"
 #include "../error.h"
+#include "../string.h"
 #include <stdexcept>
 #include <filesystem>
 
@@ -52,7 +53,8 @@ DWORD GetProcessIdFromName(const std::wstring &processName, std::function<bool(c
 		}
 	}
 
-	throw std::runtime_error("Could not find named process");
+	const auto msg = std::wstring(L"Could not find process with name \"").append(processName).append(L"\"");
+	THROW_UNCONDITIONALLY(common::string::ToAnsi(msg).c_str());
 }
 
 std::unordered_set<DWORD> GetAllProcessIdsFromName(const std::wstring &processName,
@@ -110,7 +112,7 @@ void Run(const std::wstring &path)
 	if (false == fspath.is_absolute()
 		|| false == fspath.has_filename())
 	{
-		throw std::runtime_error("Invalid path spec for subprocess");
+		THROW_UNCONDITIONALLY("Invalid path specification for subprocess");
 	}
 
 	const auto workingDir = fspath.parent_path();
@@ -135,7 +137,7 @@ void RunInContext(HANDLE securityContext, const std::wstring &path)
 	if (false == fspath.is_absolute()
 		|| false == fspath.has_filename())
 	{
-		throw std::runtime_error("Invalid path spec for subprocess");
+		THROW_UNCONDITIONALLY("Invalid path specification for subprocess");
 	}
 
 	const auto workingDir = fspath.parent_path();

--- a/src/libcommon/registry/registry.cpp
+++ b/src/libcommon/registry/registry.cpp
@@ -36,21 +36,21 @@ void DefaultMoveKey(const common::registry::RegistryPath &source, const common::
 
 	auto status = RegCreateKeyExW(destination.key(), destination.subkey().c_str(), 0, nullptr, 0, KEY_ALL_ACCESS, nullptr, &destHandle, nullptr);
 
-	THROW_UNLESS(ERROR_SUCCESS, status, "Create destination key");
+	THROW_CODE_UNLESS(ERROR_SUCCESS, status, "Create destination key");
 
 	status = RegCopyTreeW(source.key(), source.subkey().c_str(), destHandle);
 
 	RegCloseKey(destHandle);
 
-	THROW_UNLESS(ERROR_SUCCESS, status, "Copy registry key");
+	THROW_CODE_UNLESS(ERROR_SUCCESS, status, "Copy registry key");
 
 	status = RegDeleteTreeW(source.key(), source.subkey().c_str());
 
-	THROW_UNLESS(ERROR_SUCCESS, status, "Clean up source tree");
+	THROW_CODE_UNLESS(ERROR_SUCCESS, status, "Clean up source tree");
 
 	status = RegDeleteKeyW(source.key(), source.subkey().c_str());
 
-	THROW_UNLESS(ERROR_SUCCESS, status, "Clean up source key");
+	THROW_CODE_UNLESS(ERROR_SUCCESS, status, "Clean up source key");
 }
 
 } // anonymous namespace
@@ -67,7 +67,7 @@ std::unique_ptr<RegistryKey> Registry::CreateKey(HKEY key, const std::wstring &s
 
 	const auto status = RegCreateKeyExW(key, subkey.c_str(), 0, nullptr, 0, accessFlags, nullptr, &subkeyHandle, nullptr);
 
-	THROW_UNLESS(ERROR_SUCCESS, status, "Create registry key");
+	THROW_CODE_UNLESS(ERROR_SUCCESS, status, "Create registry key");
 
 	return std::make_unique<RegistryKey>(subkeyHandle);
 }
@@ -81,7 +81,7 @@ std::unique_ptr<RegistryKey> Registry::OpenKey(HKEY key, const std::wstring &sub
 
 	const auto status = RegOpenKeyExW(key, subkey.c_str(), 0, accessFlags, &subkeyHandle);
 
-	THROW_UNLESS(ERROR_SUCCESS, status, "Open registry key");
+	THROW_CODE_UNLESS(ERROR_SUCCESS, status, "Open registry key");
 
 	return std::make_unique<RegistryKey>(subkeyHandle);
 }
@@ -105,7 +105,7 @@ void Registry::DeleteKey(HKEY key, const std::wstring &subkey, RegistryView view
 	if (ERROR_SUCCESS != status
 		&& ERROR_FILE_NOT_FOUND != status)
 	{
-		THROW_WITH_CODE("Delete registry key", status);
+		THROW_CODE(status, "Delete registry key");
 	}
 }
 
@@ -128,7 +128,7 @@ void Registry::DeleteTree(HKEY key, const std::wstring &subkey, RegistryView vie
 
 		const auto openStatus = RegOpenKeyExW(key, subkey.c_str(), 0, accessFlags, &subkeyHandle);
 
-		THROW_UNLESS(ERROR_SUCCESS, openStatus, "Open registry key for deleting tree");
+		THROW_CODE_UNLESS(ERROR_SUCCESS, openStatus, "Open registry key for deleting tree");
 
 		status = RegDeleteTreeW(subkeyHandle, nullptr);
 
@@ -138,7 +138,7 @@ void Registry::DeleteTree(HKEY key, const std::wstring &subkey, RegistryView vie
 	if (ERROR_SUCCESS != status
 		&& ERROR_FILE_NOT_FOUND != status)
 	{
-		THROW_WITH_CODE("Delete registry tree", status);
+		THROW_CODE(status, "Delete registry tree");
 	}
 }
 
@@ -158,7 +158,7 @@ std::unique_ptr<RegistryMonitor> Registry::MonitorKey
 
 	const auto status = RegOpenKeyExW(key, subkey.c_str(), 0, accessFlags, &subkeyHandle);
 
-	THROW_UNLESS(ERROR_SUCCESS, status, "Open registry key for monitoring");
+	THROW_CODE_UNLESS(ERROR_SUCCESS, status, "Open registry key for monitoring");
 
 	RegistryMonitorArguments args;
 
@@ -206,24 +206,24 @@ void Registry::MoveKey
 
  	auto status = RegOpenKeyExW(source.key(), source.subkey().c_str(), 0, KEY_ALL_ACCESS | viewFlag, sourceHandle.get());
 
-	THROW_UNLESS(ERROR_SUCCESS, status, "Open source key");
+	THROW_CODE_UNLESS(ERROR_SUCCESS, status, "Open source key");
 
 	status = RegCreateKeyExW(destination.key(), destination.subkey().c_str(), 0, nullptr, 0, \
 		KEY_ALL_ACCESS | viewFlag, nullptr, destinationHandle.get(), nullptr);
 
-	THROW_UNLESS(ERROR_SUCCESS, status, "Create destination key");
+	THROW_CODE_UNLESS(ERROR_SUCCESS, status, "Create destination key");
 
 	status = RegCopyTreeW(*sourceHandle, nullptr, *destinationHandle);
 
-	THROW_UNLESS(ERROR_SUCCESS, status, "Copy registry key");
+	THROW_CODE_UNLESS(ERROR_SUCCESS, status, "Copy registry key");
 
 	status = RegDeleteTreeW(*sourceHandle, nullptr);
 
-	THROW_UNLESS(ERROR_SUCCESS, status, "Clean up source tree");
+	THROW_CODE_UNLESS(ERROR_SUCCESS, status, "Clean up source tree");
 
 	status = RegDeleteKeyExW(source.key(), source.subkey().c_str(), viewFlag, 0);
 
-	THROW_UNLESS(ERROR_SUCCESS, status, "Clean up source key");
+	THROW_CODE_UNLESS(ERROR_SUCCESS, status, "Clean up source key");
 }
 
 }

--- a/src/libcommon/registry/registrymonitor.cpp
+++ b/src/libcommon/registry/registrymonitor.cpp
@@ -11,10 +11,7 @@ RegistryMonitor::RegistryMonitor(RegistryMonitorArguments &&args)
 {
 	m_event = CreateEventW(nullptr, TRUE, FALSE, nullptr);
 
-	if (nullptr == m_event)
-	{
-		throw std::runtime_error("Could not create event for registry key monitoring");
-	}
+	THROW_IF(nullptr, m_event, "Could not create event for registry key monitoring");
 }
 
 RegistryMonitor::~RegistryMonitor()
@@ -51,14 +48,14 @@ HANDLE RegistryMonitor::queueSingleEvent()
 			}
 			default:
 			{
-				throw std::runtime_error("Invalid event flag");
+				THROW_UNCONDITIONALLY("Invalid event flag");
 			}
 		}
 	}
 
 	const auto status = RegNotifyChangeKeyValue(m_args.key, m_args.monitorTree, filter, m_event, TRUE);
 
-	THROW_UNLESS(ERROR_SUCCESS, status, "Activate registry monitoring");
+	THROW_CODE_UNLESS(ERROR_SUCCESS, status, "Activate registry monitoring");
 
 	m_hasRequestedNotification = true;
 

--- a/src/libcommon/resourcedata.cpp
+++ b/src/libcommon/resourcedata.cpp
@@ -21,10 +21,7 @@ BinaryResource LoadBinaryResource(HMODULE moduleHandle, uint32_t resourceId)
 
 	result.data = reinterpret_cast<uint8_t *>(LockResource(resourceHandle));
 
-	if (nullptr == result.data)
-	{
-		throw std::runtime_error("Failed to lock resource");
-	}
+	THROW_IF(nullptr, result.data, "Failed to lock resource");
 
 	return result;
 }

--- a/src/libcommon/security.cpp
+++ b/src/libcommon/security.cpp
@@ -30,7 +30,7 @@ void AdjustTokenPrivilege(HANDLE token, const std::wstring &privilege, bool enab
 	//
 	if (FALSE == status || ERROR_SUCCESS != error)
 	{
-		THROW_WITH_CODE("Adjust token privileges", error);
+		THROW_CODE(error, "Adjust token privileges");
 	}
 }
 
@@ -44,7 +44,7 @@ void AdjustCurrentThreadTokenPrivilege(const std::wstring &privilege, bool enabl
 	{
 		const auto error = GetLastError();
 
-		THROW_UNLESS(ERROR_NO_TOKEN, error, "Acquire access token for current thread");
+		THROW_CODE_UNLESS(ERROR_NO_TOKEN, error, "Acquire access token for current thread");
 
 		THROW_GLE_IF(FALSE, ImpersonateSelf(SecurityImpersonation), "Impersonate self");
 
@@ -117,7 +117,7 @@ void AddAdminToObjectDacl(const std::wstring &objectName, SE_OBJECT_TYPE objectT
 		&securityDescriptor
 	);
 
-	THROW_UNLESS(ERROR_SUCCESS, getSecurityStatus, "Retrieve DACL for object");
+	THROW_CODE_UNLESS(ERROR_SUCCESS, getSecurityStatus, "Retrieve DACL for object");
 
 	common::memory::ScopeDestructor sd;
 
@@ -139,7 +139,7 @@ void AddAdminToObjectDacl(const std::wstring &objectName, SE_OBJECT_TYPE objectT
 
 	const auto setEntriesStatus = SetEntriesInAclW(1, &ea, currentAcl, &updatedAcl);
 
-	THROW_UNLESS(ERROR_SUCCESS, setEntriesStatus, "Create updated DACL");
+	THROW_CODE_UNLESS(ERROR_SUCCESS, setEntriesStatus, "Create updated DACL");
 
 	sd += [&updatedAcl]()
 	{
@@ -157,7 +157,7 @@ void AddAdminToObjectDacl(const std::wstring &objectName, SE_OBJECT_TYPE objectT
 		nullptr
 	);
 
-	THROW_UNLESS(ERROR_SUCCESS, setSecurityStatus, "Apply updated DACL")
+	THROW_CODE_UNLESS(ERROR_SUCCESS, setSecurityStatus, "Apply updated DACL");
 }
 
 UniqueHandle DuplicateSecurityContext(DWORD processId)

--- a/src/libcommon/serialization/deserializer.cpp
+++ b/src/libcommon/serialization/deserializer.cpp
@@ -1,6 +1,6 @@
 #include "stdafx.h"
 #include "deserializer.h"
-#include <stdexcept>
+#include "../error.h"
 
 namespace common::serialization
 {
@@ -87,17 +87,14 @@ void Deserializer::validateType(TypeTag type)
 
 	read(&readType, sizeof(uint8_t));
 
-	if (readType != static_cast<uint8_t>(type))
-	{
-		throw std::runtime_error("Unexpected data type in stream");
-	}
+	THROW_UNLESS(static_cast<uint8_t>(type), readType, "Unexpected data type in stream");
 }
 
 void Deserializer::read(void *data, size_t length)
 {
 	if (m_offset + length > m_blob.size())
 	{
-		throw std::runtime_error("Read probe passed end of stream");
+		THROW_UNCONDITIONALLY("Read probe passed end of stream");
 	}
 
 	memcpy(data, &m_blob[m_offset], length);

--- a/src/libcommon/string.cpp
+++ b/src/libcommon/string.cpp
@@ -1,12 +1,12 @@
 #include "stdafx.h"
 #include "string.h"
 #include "memory.h"
+#include "error.h"
 #include <algorithm>
 #include <iomanip>
 #include <memory>
 #include <sddl.h>
 #include <sstream>
-#include <stdexcept>
 #include <wchar.h>
 
 namespace common::string {
@@ -15,12 +15,10 @@ std::wstring FormatGuid(const GUID &guid)
 {
 	LPOLESTR buffer;
 
-	auto status = StringFromCLSID(guid, &buffer);
-
-	if (status != S_OK)
-	{
-		throw std::runtime_error("Failed to format GUID");
-	}
+	THROW_UNLESS(S_OK,
+		StringFromCLSID(guid, &buffer),
+		"Failed to format GUID"
+	);
 
 	std::wstring formatted(buffer);
 
@@ -33,12 +31,10 @@ std::wstring FormatSid(const SID &sid)
 {
 	LPWSTR buffer;
 
-	auto status = ConvertSidToStringSidW(const_cast<SID *>(&sid), &buffer);
-
-	if (0 == status)
-	{
-		throw std::runtime_error("Failed to format SID");
-	}
+	THROW_IF(0,
+		ConvertSidToStringSidW(const_cast<SID*>(&sid), &buffer),
+		"Failed to format SID"
+	);
 
 	std::wstring formatted(buffer);
 
@@ -143,10 +139,10 @@ std::wstring FormatTime(const FILETIME &filetime)
 {
 	FILETIME ft2;
 
-	if (FALSE == FileTimeToLocalFileTime(&filetime, &ft2))
-	{
-		throw std::runtime_error("Failed to convert time");
-	}
+	THROW_IF(FALSE,
+		FileTimeToLocalFileTime(&filetime, &ft2),
+		"Failed to convert time"
+	);
 
 	return FormatLocalTime(ft2);
 }
@@ -155,10 +151,10 @@ std::wstring FormatLocalTime(const FILETIME &filetime)
 {
 	SYSTEMTIME st;
 
-	if (FALSE == FileTimeToSystemTime(&filetime, &st))
-	{
-		throw std::runtime_error("Failed to convert time");
-	}
+	THROW_IF(FALSE,
+		FileTimeToSystemTime(&filetime, &st),
+		"Failed to convert time"
+	);
 
 	std::wstringstream ss;
 
@@ -237,7 +233,7 @@ std::wstring Summary(const std::wstring &str, size_t max)
 
 	if (max < paddingLength)
 	{
-		throw std::runtime_error("Requested summary is too short");
+		THROW_UNCONDITIONALLY("Requested summary is too short");
 	}
 
 	auto summary = str.substr(0, max - paddingLength);

--- a/src/libcommon/trace/filetracesink.cpp
+++ b/src/libcommon/trace/filetracesink.cpp
@@ -21,7 +21,7 @@ FileTraceSink::FileTraceSink(const std::wstring &file)
 		const auto error = GetLastError();
 		const auto msg = std::string("Failed to create trace file: ").append(common::string::ToAnsi(file));
 
-		THROW_WITH_CODE(msg.c_str(), error);
+		THROW_CODE(error, msg.c_str());
 	}
 }
 

--- a/src/libcommon/valuemapper.h
+++ b/src/libcommon/valuemapper.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include "error.h"
 #include <algorithm>
 #include <utility>
 #include <vector>
-#include <stdexcept>
 #include <initializer_list>
 #include <optional>
 #include <sstream>
@@ -39,9 +39,8 @@ struct ValueMapper
 		ss << "Could not map between values: "
 			<< typeid(T).name() << " -> " << typeid(U).name();
 
-		throw std::runtime_error(ss.str());
+		THROW_UNCONDITIONALLY(ss.str().c_str());
 	}
-
 };
 
 }


### PR DESCRIPTION
I added more macros to have a fuller set of macros available. This has a few consequences:

- The `THROW_IF` macro had to be renamed to what it actually is: `THROW_CODE_IF`.
- Same for `THROW_UNLESS` -> `THROW_CODE_UNLESS`.
- The macros can potentially make code at the call site hard to read when so many if-statements are hidden in macros.
- Still doesn't provide a complete set macros one may need (e.g. less-than comparison).

We could either go with this, or go the other direction and try to remove macros. I don't think what is currently in `master` is good enough,

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-libraries/27)
<!-- Reviewable:end -->
