### PR TITLE
Use compact IPv6 representation

### DIFF
--- a/src/libcommon/string.h
+++ b/src/libcommon/string.h
@@ -57,7 +57,6 @@ std::wstring FormatIpv4(uint32_t ip, uint8_t routingPrefix)
 	return ss.str();
 }
 
-// TODO: Format into compact representation.
 std::wstring FormatIpv6(const uint8_t ip[16]);
 
 // TODO: Fix later if intending to produce user facing strings.


### PR DESCRIPTION
Mainly, use `::` for the longest sequence of adjacent groups of zeros. E.g.
```
	uint8_t ip1[16] = { 0 };
	uint8_t ip2[16] = { 0x10, 0x80, 0, 0, 0, 0, 0,0, 0,0x8, 0x8,0, 0x20, 0xc, 0x41, 0x7a };
	uint8_t ip3[16] = { 0xff, 0x01, 0, 0, 0, 0, 0,0, 0,0, 0, 0, 0,0, 0, 0x43 };
	uint8_t ip4[16] = { 0, 0, 0, 0, 0, 0, 0,0, 0,0, 0, 0, 0,0, 0, 0x1 };
	std::wcout << FormatIpv6(ip1) << std::endl;
	std::wcout << FormatIpv6(ip2) << std::endl;
	std::wcout << FormatIpv6(ip3) << std::endl;
	std::wcout << FormatIpv6(ip4) << std::endl;
```
outputs
```
::
1080::8:800:200c:417a
ff01::43
::1
```

Examples from here: https://tools.ietf.org/html/rfc1884

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-libraries/28)
<!-- Reviewable:end -->
