### PR TITLE
Use less magic in exception macros

### DIFF
--- a/src/libcommon/burstguard.cpp
+++ b/src/libcommon/burstguard.cpp
@@ -15,14 +15,17 @@ BurstGuard::BurstGuard(Callback callback, uint32_t burstDuration, uint32_t inter
 {
 	m_stateEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
 
-	THROW_GLE_IF(NULL, m_stateEvent, "Create BurstGuard thread state event object");
+	if (NULL == m_stateEvent)
+	{
+		THROW_WINDOWS_ERROR(GetLastError(), "Create BurstGuard thread state event object");
+	}
 
 	const auto t = _beginthreadex(nullptr, 0, BurstGuard::Thread, this, 0, nullptr);
 
 	if (0 == t)
 	{
 		CloseHandle(m_stateEvent);
-		throw std::runtime_error("Failed to create BurstGuard thread");
+		THROW_ERROR("Failed to create BurstGuard thread");
 	}
 
 	m_thread = reinterpret_cast<HANDLE>(t);

--- a/src/libcommon/burstguard.cpp
+++ b/src/libcommon/burstguard.cpp
@@ -15,7 +15,7 @@ BurstGuard::BurstGuard(Callback callback, uint32_t burstDuration, uint32_t inter
 {
 	m_stateEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
 
-	if (NULL == m_stateEvent)
+	if (nullptr == m_stateEvent)
 	{
 		THROW_WINDOWS_ERROR(GetLastError(), "Create BurstGuard thread state event object");
 	}

--- a/src/libcommon/com.h
+++ b/src/libcommon/com.h
@@ -3,7 +3,6 @@
 #include "error.h"
 #include <string>
 #include <vector>
-#include <stdexcept>
 #include <winerror.h>
 #include <atlbase.h>
 #include <comutil.h>

--- a/src/libcommon/error.cpp
+++ b/src/libcommon/error.cpp
@@ -4,7 +4,6 @@
 #include <exception>
 #include <iomanip>
 #include <sstream>
-#include <stdexcept>
 #include <cstring>
 
 namespace common::error {
@@ -37,35 +36,8 @@ const char *IsolateFilename(const char *filepath)
 
 } // anonymous namespace
 
-std::wstring FormatWindowsError(DWORD errorCode)
+std::string FormatWindowsError(DWORD errorCode)
 {
-	LPWSTR buffer;
-
-	auto status = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
-		nullptr, errorCode, 0, (LPWSTR)&buffer, 0, nullptr);
-
-	if (0 == status)
-	{
-		std::wstringstream ss;
-
-		ss << L"System error 0x" << std::setw(8) << std::setfill(L'0') << std::hex << errorCode;
-
-		return ss.str();
-	}
-
-	auto result = common::string::TrimRight(std::wstring(buffer));
-	LocalFree(buffer);
-
-	return result;
-}
-
-std::string FormatWindowsErrorPlain(DWORD errorCode)
-{
-	//
-	// Duplicated logic, but preferred to converting the string from
-	// wide char to multibyte
-	//
-
 	LPSTR buffer;
 
 	auto status = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
@@ -90,17 +62,17 @@ void Throw(const char *operation, DWORD errorCode, const char *file, size_t line
 {
 	std::stringstream ss;
 
-	ss << operation << ": " << common::error::FormatWindowsErrorPlain(errorCode)
+	ss << operation << ": " << common::error::FormatWindowsError(errorCode)
 		<< " (" << IsolateFilename(file) << ": " << line << ")";
 
 	ThrowFormatted(ss.str().c_str());
 }
 
-void Throw(const char *operation, const char *file, size_t line)
+void Throw(const char *message, const char *file, size_t line)
 {
 	std::stringstream ss;
 
-	ss << operation << " (" << IsolateFilename(file) << ": " << line << ")";
+	ss << message << " (" << IsolateFilename(file) << ": " << line << ")";
 
 	ThrowFormatted(ss.str().c_str());
 }

--- a/src/libcommon/error.h
+++ b/src/libcommon/error.h
@@ -6,52 +6,26 @@
 #include <memory>
 #include <windows.h>
 
-#define THROW_IF(unwanted, actual, operation)\
-if(actual == unwanted)\
+#define THROW_WINDOWS_ERROR(errorCode, operation)\
 {\
-	::common::error::Throw(operation, actual, __FILE__, __LINE__);\
+	::common::error::Throw(operation, errorCode, __FILE__, __LINE__);\
 }\
 
-#define THROW_UNLESS(expected, actual, operation)\
-if(actual != expected)\
+#define THROW_ERROR(message)\
 {\
-	::common::error::Throw(operation, actual, __FILE__, __LINE__);\
-}\
-
-#define THROW_GLE_UNLESS(expected, actual, operation)\
-if(actual != expected)\
-{\
-	::common::error::Throw(operation, GetLastError(), __FILE__, __LINE__);\
-}\
-
-#define THROW_GLE_IF(unwanted, actual, operation)\
-if(actual == unwanted)\
-{\
-	::common::error::Throw(operation, GetLastError(), __FILE__, __LINE__);\
-}\
-
-#define THROW_GLE(operation)\
-{\
-	::common::error::Throw(operation, GetLastError(), __FILE__, __LINE__);\
-}\
-
-#define THROW_UNCONDITIONALLY(operation)\
-{\
-	::common::error::Throw(operation, __FILE__, __LINE__);\
-}\
-
-#define THROW_WITH_CODE(operation, code)\
-{\
-	::common::error::Throw(operation, code, __FILE__, __LINE__);\
+	::common::error::Throw(message, __FILE__, __LINE__);\
 }\
 
 namespace common::error {
 
-std::wstring FormatWindowsError(DWORD errorCode);
-std::string FormatWindowsErrorPlain(DWORD errorCode);
+std::string FormatWindowsError(DWORD errorCode);
 
+//
+// Note: The errorCode argument is a system error code, and will be formatted as such.
+// For custom error codes, embed them in the message and use the overload with fewer arguments.
+//
 [[noreturn]] void Throw(const char *operation, DWORD errorCode, const char *file, size_t line);
-[[noreturn]] void Throw(const char *operation, const char *file, size_t line);
+[[noreturn]] void Throw(const char *message, const char *file, size_t line);
 
 void UnwindException(const std::exception &err, std::shared_ptr<common::logging::ILogSink> logSink);
 

--- a/src/libcommon/filesystem.cpp
+++ b/src/libcommon/filesystem.cpp
@@ -2,7 +2,6 @@
 #include "filesystem.h"
 #include "string.h"
 #include "error.h"
-#include <stdexcept>
 
 namespace common::fs
 {
@@ -57,7 +56,7 @@ void Mkdir(const std::wstring &path)
 	{
 		auto msg = std::string("Failed to create directory: ").append(common::string::ToAnsi(target));
 
-		throw std::runtime_error(msg.c_str());
+		THROW_ERROR(msg.c_str());
 	}
 }
 
@@ -76,19 +75,23 @@ std::wstring GetKnownFolderPath(REFKNOWNFOLDERID folderId, DWORD flags, HANDLE u
 		return result;
 	}
 
-	throw std::runtime_error("Failed to retrieve \"known folder\" path");
+	THROW_ERROR("Failed to retrieve \"known folder\" path");
 }
 
 ScopedNativeFileSystem::ScopedNativeFileSystem()
 {
-	const auto status = Wow64DisableWow64FsRedirection(&m_context);
-	THROW_GLE_IF(FALSE, status, "Disable file system redirection");
+	if (FALSE == Wow64DisableWow64FsRedirection(&m_context))
+	{
+		THROW_WINDOWS_ERROR(GetLastError(), "Disable file system redirection");
+	}
 }
 
 ScopedNativeFileSystem::~ScopedNativeFileSystem()
 {
-	const auto status = Wow64RevertWow64FsRedirection(m_context);
-	THROW_GLE_IF(FALSE, status, "Revert file system redirection");
+	if (FALSE == Wow64RevertWow64FsRedirection(m_context))
+	{
+		THROW_WINDOWS_ERROR(GetLastError(), "Revert file system redirection");
+	}
 }
 
 }

--- a/src/libcommon/guid.cpp
+++ b/src/libcommon/guid.cpp
@@ -13,7 +13,10 @@ GUID Guid::Generate()
 
 	const auto status = UuidCreate(&u);
 
-	THROW_UNLESS(RPC_S_OK, status, "Generate GUID");
+	if (RPC_S_OK != status)
+	{
+		THROW_WINDOWS_ERROR(status, "Generate GUID");
+	}
 
 	return u;
 }
@@ -25,7 +28,10 @@ GUID Guid::GenerateQuick()
 
 	const auto status = UuidCreateSequential(&u);
 
-	THROW_UNLESS(RPC_S_OK, status, "Generate GUID");
+	if (RPC_S_OK != status)
+	{
+		THROW_WINDOWS_ERROR(status, "Generate GUID");
+	}
 
 	return u;
 }
@@ -61,7 +67,7 @@ GUID Guid::FromString(const std::wstring &guid)
 		}
 		default:
 		{
-			throw std::runtime_error("Invalid GUID format");
+			THROW_ERROR("Invalid GUID format");
 		}
 	}
 
@@ -71,7 +77,10 @@ GUID Guid::FromString(const std::wstring &guid)
 
 	const auto status = UuidFromStringW(lolwindows, &convertedGuid);
 
-	THROW_UNLESS(RPC_S_OK, status, "Convert formatted GUID to raw representation");
+	if (RPC_S_OK != status)
+	{
+		THROW_WINDOWS_ERROR(status, "Convert formatted GUID to raw representation");
+	}
 
 	return convertedGuid;
 }

--- a/src/libcommon/network/adapters.cpp
+++ b/src/libcommon/network/adapters.cpp
@@ -2,7 +2,6 @@
 #include "adapters.h"
 #include "libcommon/error.h"
 #include <sstream>
-#include <stdexcept>
 
 namespace common::network
 {
@@ -51,7 +50,10 @@ Adapters::Adapters(DWORD family, DWORD flags)
 			return;
 		}
 
-		THROW_UNLESS(ERROR_BUFFER_OVERFLOW, status, "Probe required buffer size for GetAdaptersAddresses");
+		if (ERROR_BUFFER_OVERFLOW != status)
+		{
+			THROW_WINDOWS_ERROR(status, "Probe required buffer size for GetAdaptersAddresses");
+		}
 
 		buffer.resize(bufferSize);
 		bufferPointer = reinterpret_cast<IP_ADAPTER_ADDRESSES *>(&buffer[0]);
@@ -72,7 +74,7 @@ Adapters::Adapters(DWORD family, DWORD flags)
 		ss << "Expecting IP_ADAPTER_ADDRESSES to have size " << codeSize << " bytes. "
 			<< "Found structure with size " << systemSize << " bytes.";
 
-		throw std::runtime_error(ss.str());
+		THROW_ERROR(ss.str().c_str());
 	}
 
 	//

--- a/src/libcommon/registry/registrykey.cpp
+++ b/src/libcommon/registry/registrykey.cpp
@@ -17,7 +17,12 @@ RegistryKey::~RegistryKey()
 
 void RegistryKey::flush()
 {
-	THROW_UNLESS(ERROR_SUCCESS, RegFlushKey(m_key), "Flush registry key");
+	const auto status = RegFlushKey(m_key);
+
+	if (ERROR_SUCCESS != status)
+	{
+		THROW_WINDOWS_ERROR(status, "Flush registry key");
+	}
 }
 
 void RegistryKey::writeValue(const std::wstring &valueName, const std::wstring &valueData, ValueStringType type)
@@ -27,7 +32,10 @@ void RegistryKey::writeValue(const std::wstring &valueName, const std::wstring &
 	const auto status = RegSetValueExW(m_key, valueName.c_str(), 0, static_cast<DWORD>(type),
 		reinterpret_cast<const BYTE *>(valueData.c_str()), dataLength);
 
-	THROW_UNLESS(ERROR_SUCCESS, status, "Write registry value");
+	if (ERROR_SUCCESS != status)
+	{
+		THROW_WINDOWS_ERROR(status, "Write registry value");
+	}
 }
 
 void RegistryKey::writeValue(const std::wstring &valueName, uint32_t valueData)
@@ -35,7 +43,10 @@ void RegistryKey::writeValue(const std::wstring &valueName, uint32_t valueData)
 	const auto status = RegSetValueExW(m_key, valueName.c_str(), 0, REG_DWORD,
 		reinterpret_cast<const BYTE *>(&valueData), sizeof(uint32_t));
 
-	THROW_UNLESS(ERROR_SUCCESS, status, "Write registry value");
+	if (ERROR_SUCCESS != status)
+	{
+		THROW_WINDOWS_ERROR(status, "Write registry value");
+	}
 }
 
 void RegistryKey::writeValue(const std::wstring &valueName, uint64_t valueData)
@@ -43,7 +54,10 @@ void RegistryKey::writeValue(const std::wstring &valueName, uint64_t valueData)
 	const auto status = RegSetValueExW(m_key, valueName.c_str(), 0, REG_QWORD,
 		reinterpret_cast<const BYTE *>(&valueData), sizeof(uint64_t));
 
-	THROW_UNLESS(ERROR_SUCCESS, status, "Write registry value");
+	if (ERROR_SUCCESS != status)
+	{
+		THROW_WINDOWS_ERROR(status, "Write registry value");
+	}
 }
 
 void RegistryKey::writeValue(const std::wstring &valueName, const std::vector<uint8_t> &valueData)
@@ -53,7 +67,10 @@ void RegistryKey::writeValue(const std::wstring &valueName, const std::vector<ui
 	const auto status = RegSetValueExW(m_key, valueName.c_str(), 0, REG_BINARY,
 		&valueData[0], dataLength);
 
-	THROW_UNLESS(ERROR_SUCCESS, status, "Write registry value");
+	if (ERROR_SUCCESS != status)
+	{
+		THROW_WINDOWS_ERROR(status, "Write registry value");
+	}
 }
 
 void RegistryKey::writeValue(const std::wstring &valueName, const std::vector<std::wstring> &valueData)
@@ -90,14 +107,20 @@ void RegistryKey::writeValue(const std::wstring &valueName, const std::vector<st
 	const auto status = RegSetValueExW(m_key, valueName.c_str(), 0, REG_MULTI_SZ,
 		reinterpret_cast<const BYTE *>(&buffer[0]), dataLength);
 
-	THROW_UNLESS(ERROR_SUCCESS, status, "Write registry value");
+	if (ERROR_SUCCESS != status)
+	{
+		THROW_WINDOWS_ERROR(status, "Write registry value");
+	}
 }
 
 void RegistryKey::deleteValue(const std::wstring &valueName)
 {
 	const auto status = RegDeleteValueW(m_key, valueName.c_str());
 
-	THROW_UNLESS(ERROR_SUCCESS, status, "Delete registry value");
+	if (ERROR_SUCCESS != status)
+	{
+		THROW_WINDOWS_ERROR(status, "Delete registry value");
+	}
 }
 
 std::wstring RegistryKey::readString(const std::wstring &valueName, ValueStringType type) const
@@ -205,7 +228,10 @@ void RegistryKey::enumerateSubKeys(std::function<bool(const std::wstring &)> cal
 	const auto queryStatus = RegQueryInfoKeyW(m_key, nullptr, nullptr, nullptr, nullptr,
 		&longestSubKeyName, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
 
-	THROW_UNLESS(ERROR_SUCCESS, queryStatus, "Query for longest subkey name length");
+	if (ERROR_SUCCESS != queryStatus)
+	{
+		THROW_WINDOWS_ERROR(queryStatus, "Query for longest subkey name length");
+	}
 
 	std::vector<wchar_t> buffer(longestSubKeyName + 1);
 
@@ -230,7 +256,10 @@ void RegistryKey::enumerateSubKeys(std::function<bool(const std::wstring &)> cal
 			continue;
 		}
 
-		THROW_UNLESS(ERROR_SUCCESS, enumStatus, "Enumerate next subkey");
+		if (ERROR_SUCCESS != enumStatus)
+		{
+			THROW_WINDOWS_ERROR(enumStatus, "Enumerate next subkey");
+		}
 
 		if (false == callback(std::wstring(&buffer[0])))
 		{
@@ -248,7 +277,10 @@ void RegistryKey::enumerateValues(std::function<bool(const std::wstring &, uint3
 	const auto queryStatus = RegQueryInfoKeyW(m_key, nullptr, nullptr, nullptr, nullptr,
 		nullptr, nullptr, nullptr, &longestValueName, nullptr, nullptr, nullptr);
 
-	THROW_UNLESS(ERROR_SUCCESS, queryStatus, "Query for longest value name length");
+	if (ERROR_SUCCESS != queryStatus)
+	{
+		THROW_WINDOWS_ERROR(queryStatus, "Query for longest value name length");
+	}
 
 	std::vector<wchar_t> buffer(longestValueName + 1);
 
@@ -274,7 +306,10 @@ void RegistryKey::enumerateValues(std::function<bool(const std::wstring &, uint3
 			continue;
 		}
 
-		THROW_UNLESS(ERROR_SUCCESS, enumStatus, "Enumerate next value");
+		if (ERROR_SUCCESS != enumStatus)
+		{
+			THROW_WINDOWS_ERROR(enumStatus, "Enumerate next value");
+		}
 
 		if (false == callback(std::wstring(&buffer[0]), valueType))
 		{
@@ -292,11 +327,14 @@ std::vector<uint8_t> RegistryKey::readRaw(const std::wstring &valueName, DWORD d
 
 	auto status = RegQueryValueExW(m_key, valueName.c_str(), nullptr, &actualDataType, nullptr, &dataSize);
 
-	THROW_UNLESS(ERROR_SUCCESS, status, "Query for registry value data type and data length");
+	if (ERROR_SUCCESS != status)
+	{
+		THROW_WINDOWS_ERROR(status, "Query for registry value data type and data length");
+	}
 
 	if (actualDataType != dataType)
 	{
-		throw std::runtime_error("Unexpected registry value data type");
+		THROW_ERROR("Unexpected registry value data type");
 	}
 
 	if (0 == dataSize)
@@ -308,7 +346,10 @@ std::vector<uint8_t> RegistryKey::readRaw(const std::wstring &valueName, DWORD d
 
 	status = RegQueryValueExW(m_key, valueName.c_str(), nullptr, nullptr, &buffer[0], &dataSize);
 
-	THROW_UNLESS(ERROR_SUCCESS, status, "Read registry value");
+	if (ERROR_SUCCESS != status)
+	{
+		THROW_WINDOWS_ERROR(status, "Read registry value");
+	}
 
 	return buffer;
 }

--- a/src/libcommon/registry/registrymonitor.cpp
+++ b/src/libcommon/registry/registrymonitor.cpp
@@ -1,7 +1,6 @@
 #include "stdafx.h"
 #include "registrymonitor.h"
 #include <libcommon/error.h>
-#include <stdexcept>
 
 namespace common::registry
 {
@@ -13,7 +12,7 @@ RegistryMonitor::RegistryMonitor(RegistryMonitorArguments &&args)
 
 	if (nullptr == m_event)
 	{
-		throw std::runtime_error("Could not create event for registry key monitoring");
+		THROW_ERROR("Could not create event for registry key monitoring");
 	}
 }
 
@@ -51,14 +50,17 @@ HANDLE RegistryMonitor::queueSingleEvent()
 			}
 			default:
 			{
-				throw std::runtime_error("Invalid event flag");
+				THROW_ERROR("Invalid event flag");
 			}
 		}
 	}
 
 	const auto status = RegNotifyChangeKeyValue(m_args.key, m_args.monitorTree, filter, m_event, TRUE);
 
-	THROW_UNLESS(ERROR_SUCCESS, status, "Activate registry monitoring");
+	if (ERROR_SUCCESS != status)
+	{
+		THROW_WINDOWS_ERROR(status, "Activate registry monitoring");
+	}
 
 	m_hasRequestedNotification = true;
 

--- a/src/libcommon/registry/registrypath.cpp
+++ b/src/libcommon/registry/registrypath.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "registrypath.h"
 #include <libcommon/string.h>
-#include <stdexcept>
+#include <libcommon/error.h>
 
 namespace common::registry
 {
@@ -12,7 +12,7 @@ RegistryPath::RegistryPath(const std::wstring &path)
 
 	if (pathTokens.size() < 2)
 	{
-		throw std::invalid_argument("Invalid registry path");
+		THROW_ERROR("Invalid registry path");
 	}
 
 	const auto keyName = pathTokens[0];
@@ -69,7 +69,7 @@ RegistryPath::RegistryPath(const std::wstring &path)
 	}
 	else
 	{
-		throw std::invalid_argument("Invalid registry root");
+		THROW_ERROR("Invalid registry root");
 	}
 
 	//

--- a/src/libcommon/resourcedata.cpp
+++ b/src/libcommon/resourcedata.cpp
@@ -1,7 +1,6 @@
 #include "stdafx.h"
 #include "resourcedata.h"
 #include "error.h"
-#include <stdexcept>
 
 namespace common::resourcedata {
 
@@ -9,7 +8,10 @@ BinaryResource LoadBinaryResource(HMODULE moduleHandle, uint32_t resourceId)
 {
 	auto resourceInformationBlock = FindResourceW(moduleHandle, MAKEINTRESOURCEW(resourceId), RT_RCDATA);
 
-	THROW_GLE_IF(resourceInformationBlock, nullptr, "Locate resource information block");
+	if (nullptr == resourceInformationBlock)
+	{
+		THROW_WINDOWS_ERROR(GetLastError(), "Locate resource information block");
+	}
 
 	BinaryResource result;
 
@@ -17,13 +19,16 @@ BinaryResource LoadBinaryResource(HMODULE moduleHandle, uint32_t resourceId)
 
 	auto resourceHandle = LoadResource(moduleHandle, resourceInformationBlock);
 
-	THROW_GLE_IF(resourceHandle, nullptr, "Load resource data");
+	if (nullptr == resourceHandle)
+	{
+		THROW_WINDOWS_ERROR(GetLastError(), "Load resource data");
+	}
 
 	result.data = reinterpret_cast<uint8_t *>(LockResource(resourceHandle));
 
 	if (nullptr == result.data)
 	{
-		throw std::runtime_error("Failed to lock resource");
+		THROW_ERROR("Failed to lock resource");
 	}
 
 	return result;

--- a/src/libcommon/serialization/deserializer.cpp
+++ b/src/libcommon/serialization/deserializer.cpp
@@ -1,6 +1,6 @@
 #include "stdafx.h"
 #include "deserializer.h"
-#include <stdexcept>
+#include "../error.h"
 
 namespace common::serialization
 {
@@ -89,7 +89,7 @@ void Deserializer::validateType(TypeTag type)
 
 	if (readType != static_cast<uint8_t>(type))
 	{
-		throw std::runtime_error("Unexpected data type in stream");
+		THROW_ERROR("Unexpected data type in stream");
 	}
 }
 
@@ -97,7 +97,7 @@ void Deserializer::read(void *data, size_t length)
 {
 	if (m_offset + length > m_blob.size())
 	{
-		throw std::runtime_error("Read probe passed end of stream");
+		THROW_ERROR("Read probe passed end of stream");
 	}
 
 	memcpy(data, &m_blob[m_offset], length);

--- a/src/libcommon/string.cpp
+++ b/src/libcommon/string.cpp
@@ -1,14 +1,13 @@
 #include "stdafx.h"
 #include "string.h"
 #include "memory.h"
+#include "error.h"
 #include <algorithm>
 #include <iomanip>
 #include <optional>
 #include <memory>
 #include <sddl.h>
 #include <sstream>
-#include <stdexcept>
-#include <string>
 #include <wchar.h>
 
 namespace
@@ -70,7 +69,7 @@ std::wstring FormatGuid(const GUID &guid)
 
 	if (status != S_OK)
 	{
-		throw std::runtime_error("Failed to format GUID");
+		THROW_ERROR("Failed to format GUID");
 	}
 
 	std::wstring formatted(buffer);
@@ -88,7 +87,7 @@ std::wstring FormatSid(const SID &sid)
 
 	if (0 == status)
 	{
-		throw std::runtime_error("Failed to format SID");
+		THROW_ERROR("Failed to format SID");
 	}
 
 	std::wstring formatted(buffer);
@@ -238,7 +237,7 @@ std::wstring FormatTime(const FILETIME &filetime)
 
 	if (FALSE == FileTimeToLocalFileTime(&filetime, &ft2))
 	{
-		throw std::runtime_error("Failed to convert time");
+		THROW_ERROR("Failed to convert time");
 	}
 
 	return FormatLocalTime(ft2);
@@ -250,7 +249,7 @@ std::wstring FormatLocalTime(const FILETIME &filetime)
 
 	if (FALSE == FileTimeToSystemTime(&filetime, &st))
 	{
-		throw std::runtime_error("Failed to convert time");
+		THROW_ERROR("Failed to convert time");
 	}
 
 	std::wstringstream ss;
@@ -330,7 +329,7 @@ std::wstring Summary(const std::wstring &str, size_t max)
 
 	if (max < paddingLength)
 	{
-		throw std::runtime_error("Requested summary is too short");
+		THROW_ERROR("Requested summary is too short");
 	}
 
 	auto summary = str.substr(0, max - paddingLength);

--- a/src/libcommon/trace/filetracesink.cpp
+++ b/src/libcommon/trace/filetracesink.cpp
@@ -21,7 +21,7 @@ FileTraceSink::FileTraceSink(const std::wstring &file)
 		const auto error = GetLastError();
 		const auto msg = std::string("Failed to create trace file: ").append(common::string::ToAnsi(file));
 
-		THROW_WITH_CODE(msg.c_str(), error);
+		THROW_WINDOWS_ERROR(error, msg.c_str());
 	}
 }
 
@@ -41,7 +41,7 @@ void FileTraceSink::trace(const wchar_t *sender, const wchar_t *message)
 
 	if (FALSE == WriteFile(m_file, encoded.c_str(), static_cast<DWORD>(encoded.size()), &bytesWritten, nullptr))
 	{
-		THROW_GLE("Failed to write trace event to disk");
+		THROW_WINDOWS_ERROR(GetLastError(), "Failed to write trace event to disk");
 	}
 }
 

--- a/src/libcommon/valuemapper.h
+++ b/src/libcommon/valuemapper.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include "error.h"
 #include <algorithm>
 #include <utility>
 #include <vector>
-#include <stdexcept>
 #include <initializer_list>
 #include <optional>
 #include <sstream>
@@ -39,7 +39,7 @@ struct ValueMapper
 		ss << "Could not map between values: "
 			<< typeid(T).name() << " -> " << typeid(U).name();
 
-		throw std::runtime_error(ss.str());
+		THROW_ERROR(ss.str().c_str());
 	}
 
 };


### PR DESCRIPTION
This changeset removes all hidden logic and assumptions from the exception macros:

- Removes conditional logic in macros.
- Removes hidden assumption about the `actual` argument to `THROW_IF` (that it's a valid Windows error code).
- Removes abbreviations (`GLE` meaning `GetLastError()`).
- Removes all but two macros to ensure logic is explicit at the call site.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-libraries/29)
<!-- Reviewable:end -->
