### PR TITLE
Simplify formatting of IP addresses

### DIFF
--- a/src/libcommon/libcommon.vcxproj
+++ b/src/libcommon/libcommon.vcxproj
@@ -177,8 +177,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <Lib>
-      <AdditionalDependencies>
-      </AdditionalDependencies>
+      <AdditionalDependencies>ntdll.lib</AdditionalDependencies>
     </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -197,8 +196,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <Lib>
-      <AdditionalDependencies>
-      </AdditionalDependencies>
+      <AdditionalDependencies>ntdll.lib</AdditionalDependencies>
     </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -221,8 +219,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <Lib>
-      <AdditionalDependencies>
-      </AdditionalDependencies>
+      <AdditionalDependencies>ntdll.lib</AdditionalDependencies>
     </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -245,8 +242,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <Lib>
-      <AdditionalDependencies>
-      </AdditionalDependencies>
+      <AdditionalDependencies>ntdll.lib</AdditionalDependencies>
     </Lib>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/libcommon/stdafx.h
+++ b/src/libcommon/stdafx.h
@@ -7,9 +7,9 @@
 
 #include "targetver.h"
 
-#define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
-
+#include <winsock2.h>
 #include <windows.h>
+
 #include <algorithm>
 #include <functional>
 #include <iomanip>

--- a/src/libcommon/string.cpp
+++ b/src/libcommon/string.cpp
@@ -212,7 +212,7 @@ std::vector<uint8_t> ToUtf8(const std::wstring &str)
 		CP_UTF8,
 		0,
 		str.c_str(),
-		str.size(),
+		static_cast<int>(str.size()),
 		nullptr,
 		0,
 		nullptr,
@@ -230,9 +230,9 @@ std::vector<uint8_t> ToUtf8(const std::wstring &str)
 		CP_UTF8,
 		0,
 		str.c_str(),
-		str.size(),
+		static_cast<int>(str.size()),
 		reinterpret_cast<char *>(rawString.data()),
-		rawString.size() - 1,
+		static_cast<int>(rawString.size() - 1),
 		nullptr,
 		nullptr
 	))

--- a/src/libcommon/string.cpp
+++ b/src/libcommon/string.cpp
@@ -15,6 +15,7 @@
 
 namespace {
 
+constexpr size_t MAX_IPV4_STRING_LENGTH = 16;
 constexpr size_t MAX_IPV6_STRING_LENGTH = 46;
 
 } // anonymous namespace
@@ -94,29 +95,21 @@ std::wstring Join(const std::vector<std::wstring> &parts, const std::wstring &de
 }
 
 template<>
-std::wstring FormatIpv4<AddressOrder::HostByteOrder>(uint32_t ip)
+std::wstring FormatIpv4<AddressOrder::NetworkByteOrder>(uint32_t ip)
 {
-	std::wstringstream ss;
+	in_addr addr;
+	addr.S_un.S_addr = ip;
 
-	ss << ((ip & 0xFF000000) >> 24) << L'.'
-		<< ((ip & 0x00FF0000) >> 16) << L'.'
-		<< ((ip & 0x0000FF00) >> 8) << L'.'
-		<< ((ip & 0x000000FF));
+	std::vector<wchar_t> ipString(MAX_IPV4_STRING_LENGTH + 1);
+	RtlIpv4AddressToStringW(&addr, ipString.data());
 
-	return ss.str();
+	return ipString.data();
 }
 
 template<>
-std::wstring FormatIpv4<AddressOrder::NetworkByteOrder>(uint32_t ip)
+std::wstring FormatIpv4<AddressOrder::HostByteOrder>(uint32_t ip)
 {
-	std::wstringstream ss;
-
-	ss << ((ip & 0x000000FF)) << L'.'
-		<< ((ip & 0x0000FF00) >> 8) << L'.'
-		<< ((ip & 0x00FF0000) >> 16) << L'.'
-		<< ((ip & 0xFF000000) >> 24);
-
-	return ss.str();
+	return FormatIpv4<AddressOrder::NetworkByteOrder>(htonl(ip));
 }
 
 std::wstring FormatIpv6(const uint8_t ip[16])


### PR DESCRIPTION
Instead of formatting IPv6 addresses ourselves, use `RtlIpv6AddressToStringW`. Similarly with IPv4 addresses.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-libraries/32)
<!-- Reviewable:end -->
