### PR TITLE
Fix error formatting and string conversions

### DIFF
--- a/src/libcommon/error.cpp
+++ b/src/libcommon/error.cpp
@@ -40,7 +40,7 @@ std::string FormatWindowsError(DWORD errorCode)
 {
 	LPSTR buffer;
 
-	auto status = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
+	auto status = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
 		nullptr, errorCode, 0, (LPSTR)&buffer, 0, nullptr);
 
 	if (0 == status)

--- a/src/libcommon/string.h
+++ b/src/libcommon/string.h
@@ -79,9 +79,9 @@ bool BeginsWith(const std::basic_string<T> &hay, const std::basic_string<T> &nee
 
 std::wstring Lower(const std::wstring &str);
 std::vector<std::wstring> Tokenize(const std::wstring &str, const std::wstring &delimiters);
-std::vector<uint8_t> ToUtf8(const std::wstring &str);
-std::string ToAnsi(const std::wstring &str);
-std::wstring ToWide(const std::string &str);
+std::vector<uint8_t> ToUtf8(const std::wstring &str, bool throwOnError = false);
+std::string ToAnsi(const std::wstring &str, bool throwOnError = false);
+std::wstring ToWide(const std::string &str, bool throwOnError = false);
 
 std::wstring Summary(const std::wstring &str, size_t max);
 


### PR DESCRIPTION
Strings were not converted between UTF16 (`std::wstring`) and ANSI correctly, particularly ANSI string to `std::wstring` conversions.

For example, in install.log, I would see
```
[2020-02-18 16:50:02.394] Failed to remove relay cache: Retrieve DACL for object: Det g￥r inte att hitta filen. (security.cpp: 149)
```

The correct output is
```
[2020-02-18 16:50:02.394] Failed to remove relay cache: Retrieve DACL for object: Det går inte att hitta filen. (security.cpp: 149)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-libraries/33)
<!-- Reviewable:end -->
