### PR TITLE
Free path buffer when `SHGetKnownFolderPath` fails

### DIFF
--- a/src/libcommon/filesystem.cpp
+++ b/src/libcommon/filesystem.cpp
@@ -62,7 +62,7 @@ void Mkdir(const std::wstring &path)
 
 std::wstring GetKnownFolderPath(REFKNOWNFOLDERID folderId, DWORD flags, HANDLE userToken)
 {
-	PWSTR folder;
+	PWSTR folder = nullptr;
 
 	const auto status = SHGetKnownFolderPath(folderId, flags, userToken, &folder);
 
@@ -74,6 +74,8 @@ std::wstring GetKnownFolderPath(REFKNOWNFOLDERID folderId, DWORD flags, HANDLE u
 
 		return result;
 	}
+
+	CoTaskMemFree(folder);
 
 	THROW_ERROR("Failed to retrieve \"known folder\" path");
 }

--- a/src/libcommon/filesystem.h
+++ b/src/libcommon/filesystem.h
@@ -9,7 +9,7 @@ namespace common::fs
 
 void Mkdir(const std::wstring &path);
 
-std::wstring GetKnownFolderPath(REFKNOWNFOLDERID folderId, DWORD flags, HANDLE userToken);
+std::wstring GetKnownFolderPath(REFKNOWNFOLDERID folderId, DWORD flags = KF_FLAG_DEFAULT, HANDLE userToken = nullptr);
 
 class ScopedNativeFileSystem
 {

--- a/src/libcommon/network/nci.cpp
+++ b/src/libcommon/network/nci.cpp
@@ -9,11 +9,7 @@ namespace common::network
 
 Nci::Nci()
 {
-	const auto systemDir = common::fs::GetKnownFolderPath(
-		FOLDERID_System,
-		KF_FLAG_DEFAULT,
-		nullptr
-	);
+	const auto systemDir = common::fs::GetKnownFolderPath(FOLDERID_System);
 	const auto nciPath = std::filesystem::path(systemDir).append(L"nci.dll");
 
 	m_dllHandle = LoadLibraryW(nciPath.c_str());


### PR DESCRIPTION
As the docs point out, the caller should free this even if `SHGetKnownFolderPath` fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-libraries/39)
<!-- Reviewable:end -->
